### PR TITLE
VoterInterface as BootstrapBundle interface

### DIFF
--- a/Voter/RequestRegexVoter.php
+++ b/Voter/RequestRegexVoter.php
@@ -8,7 +8,7 @@
 namespace Braincrafted\BootstrapBundle\Voter;
 
 use Knp\Menu\ItemInterface;
-use Knp\Menu\Matcher\Voter\VoterInterface;
+use Braincrafted\BootstrapBundle\Voter\VoterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/Voter/RequestVoter.php
+++ b/Voter/RequestVoter.php
@@ -8,7 +8,7 @@
 namespace Braincrafted\BootstrapBundle\Voter;
 
 use Knp\Menu\ItemInterface;
-use Knp\Menu\Matcher\Voter\VoterInterface;
+use Braincrafted\BootstrapBundle\Voter\VoterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/Voter/VoterInterface.php
+++ b/Voter/VoterInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Braincrafted\BootstrapBundle\Voter;
+
+use Knp\Menu\ItemInterface;
+
+/**
+ * Interface implemented by the matching voters
+ */
+interface VoterInterface
+{
+    /**
+     * Checks whether an item is current.
+     *
+     * If the voter is not able to determine a result,
+     * it should return null to let other voters do the job.
+     *
+     * @param ItemInterface $item
+     *
+     * @return boolean|null
+     */
+    public function matchItem(ItemInterface $item);
+}


### PR DESCRIPTION
BootstrapBundle doesn't work with SonataAdminBundle because of KnpMenuBundle dependencies error in composer.json - BootstrapBundle use non-existing VoterInterface interface.

The solution is to add a VoterInterafe interface as BootstrapBundle interface. 
