### PR TITLE
Add icon to prepend input field

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -34,11 +34,23 @@
 {% block form_widget_prepend_append_input %}
 {% spaceless %}
     <div class="input-prepend input-append">
-        <span class="add-on">{{ attr.prepend_input|trans({}, translation_domain) }}</span>
+        <span class="add-on">
+        {% if attr.prepend_input.icon is defined and attr.prepend_input.icon is not empty %}
+            <i class="{{ attr.prepend_input.icon }}"></i>
+        {% else %}
+            {{ attr.prepend_input|trans({}, translation_domain) }}
+        {% endif %}
+        </span>
         {% set append_input = attr.append_input|trans({}, translation_domain) %}
         {% set attr = attr|merge({'prepend_input': '', 'append_input': ''}) %}
         {{ block('form_widget_simple') }}
-        <span class="add-on">{{ append_input }}</span>
+        <span class="add-on">
+        {% if attr.append_input.icon is defined and attr.append_input.icon is not empty %}
+            <i class="{{ attr.append_input.icon }}"></i>
+        {% else %}
+            {{ append_input }}
+        {% endif %}
+        </span>
     </div>
 {% endspaceless %}
 {% endblock form_widget_prepend_append_input %}
@@ -65,7 +77,13 @@
         {% set append_input = attr.append_input|trans({}, translation_domain) %}
         {% set attr = attr|merge({'append_input': ''}) %}
         {{ block('form_widget_simple') }}
-        <span class="add-on">{{ append_input }}</span>
+        <span class="add-on">
+        {% if attr.append_input.icon is defined and attr.append_input.icon is not empty %}
+            <i class="{{ attr.append_input.icon }}"></i>
+        {% else %}
+            {{ append_input }}
+        {% endif %}
+        </span>
     </div>
 {% endspaceless %}
 {% endblock form_widget_append_input %}


### PR DESCRIPTION
This request adds the possibility to add an icon to input fields as shown in http://twitter.github.com/bootstrap/base-css.html#icons under the Form fields section.
This is done by extending the prepend input behaviour.

To add an icon to your text/number input field, simply add an array to prepend input with the icon name.

Example:

``` php
$builder
->add('start_date', null, [
                'widget' => 'single_text',
                'format' => 'yyyy-MM-dd',
                'attr' => [
                    'class' => 'datepicker span2',
                    'prepend_input' => [
                        'icon' => 'icon-calendar'
                    ]
                ]
            ]
);
```
