### PR TITLE
Calling knp_menu_render without nav_type throws error

### DIFF
--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -108,9 +108,9 @@
     {%- if item.actsLikeLast %}
         {%- set classes = classes|merge([options.lastClass]) %}
     {%- endif %}
-    {%- if item.hasChildren and (options.nav_type == 'list' or options.currentDepth is not sameas(1)) %}
+    {%- if item.hasChildren and ((options.nav_type is defined and options.nav_type == 'list') or options.currentDepth is not sameas(1)) %}
         {%- set classes = classes|merge(['nav-header']) %}
-    {%- elseif item.hasChildren and options.nav_type in ['tabs', 'pills', 'navbar'] %}
+    {%- elseif item.hasChildren and options.nav_type is defined and options.nav_type in ['tabs', 'pills', 'navbar'] %}
         {%- set classes = classes|merge(['dropdown']) %}
     {%- endif %}
 


### PR DESCRIPTION
Calling the twig function `knp_menu_render` without the parameter `nav_type` throws the following error:

```
Item "nav_type" for "Array" does not exist in
BraincraftedBootstrapBundle:Menu:menu.html.twig at line 111
```

The is also reported in #13. I 've added the missing definition checks.

This is my first pull request. Please let me know if I'm doing something wrong here :)
