### PR TITLE
Let the choice label determine its own label

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -127,7 +127,7 @@
 {% spaceless %}
     {% set child_vars = {'attr': attr} %}
     {% for child in form %}
-        {{ form_label(child, label, child_vars) }}
+        {{ form_label(child, null, child_vars) }}
     {% endfor %}
 {% endspaceless %}
 {% endblock choice_widget_expanded %}


### PR DESCRIPTION
Don't pass the parent forms label to the choice form label, fixes #22
