### PR TITLE
Modified the Menu Template to NOT need the Matcher Object

### DIFF
--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -97,9 +97,9 @@
 {% if item.displayed %}
 {# building the class of the item #}
     {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
-    {%- if matcher.isCurrent(item) %}
+    {%- if item.current %}
         {%- set classes = classes|merge([options.currentClass]) %}
-    {%- elseif matcher.isAncestor(item, options.depth) %}
+    {%- elseif item.currentAncestor %}
         {%- set classes = classes|merge([options.ancestorClass]) %}
     {%- endif %}
     {%- if item.actsLikeFirst %}
@@ -130,7 +130,7 @@
         {%- if attributes.divider is defined and attributes.divider is not empty %}
         {%- elseif item.hasChildren and options.nav_type is defined and options.nav_type in ['tabs', 'pills', 'navbar'] and options.currentDepth is sameas(1) %}
         {{ block('dropdownElement') }}
-        {%- elseif item.uri is not empty and (not matcher.isCurrent(item) or options.currentAsLink) %}
+        {%- elseif item.uri is not empty and (not item.current or options.currentAsLink) %}
         {{ block('linkElement') }}
         {%- else %}
         {{ block('spanElement') }}


### PR DESCRIPTION
Since the Matcher Object is not present in the Stable Version of
KnpMenuBundle, I adapted the Template to render the menu as in
KnpMenuBundle, without using the Matcher. The current item of the Menu
must be set on the Menu Builder.

This is done by adding to your Menu Builder the following line at the creation method:

`$menu->setCurrentUri($this->container->get('request')->getRequestUri());`

That way, the Matcher is no longer needed. Besides, this is the way to set the current Menu item on the last stable version of KnpMenuBundle.

Maybe you could create a specific TAG describing the solved Issue. Me and a couple of guys will be very grateful of that.

I had some time today, to research over this, and without beeing an expert on KnpMenuBundle, nor even Symfony; I came out with this solution that worked for me. Not sure if it will work on every single Menu scenario, but we can give it a try.

Thanks for the great job !!
