### PR TITLE
Add option to use white icons with KnpMenu

### DIFF
--- a/Twig/BootstrapIconExtension.php
+++ b/Twig/BootstrapIconExtension.php
@@ -47,8 +47,9 @@ class BootstrapIconExtension extends Twig_Extension
         $that = $this;
 
         return preg_replace_callback(
-            '/\.icon-([a-z0-9-]+)/',
+            '/\.icon-([a-z0-9-]+)(\((white|black)\))?/',
             function ($matches) use ($color, $that) {
+                $color = isset($matches[3]) ? $matches[3] : $color;
                 return $that->iconFilter($matches[1], $color);
             },
             $text


### PR DESCRIPTION
I'm using inversed bootstrap menu, so i need to use white icons, but there is no option to use it with menu.

Now you can add icon ot menu using this code:

``` php
$menu->addChild('.icon-home Home', array('uri' => '#'));
```

i added option to select color:

``` php
$menu->addChild('.icon-home(white) Home', array('uri' => '#'));
```
