### PR TITLE
Nested forms uses <legend> to render its label

### DIFF
--- a/Form/Extension/TypeSetterExtension.php
+++ b/Form/Extension/TypeSetterExtension.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bc\Bundle\BootstrapBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormInterface;
+
+class TypeSetterExtension extends AbstractTypeExtension
+{
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['type'] = $form->getConfig()->getType()->getName();
+    }
+
+    public function getExtendedType()
+    {
+        return "form";
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,3 +13,7 @@ services:
         class: Bc\Bundle\BootstrapBundle\Twig\BootstrapBadgeExtension
         tags:
             - { name: twig.extension }
+    bc_bootstrap.form.extension.typesetter_extension:
+        class: Bc\Bundle\BootstrapBundle\Form\Extension\TypeSetterExtension
+        tags:
+            - { name: form.type_extension, alias: form }

--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -303,7 +303,11 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+    {% if type == 'form' %}
+        <legend{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</legend>
+    {% else %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+    {% endif %}
 {% endspaceless %}
 {% endblock form_label %}
 


### PR DESCRIPTION
Hello, 

I'm working on a project and we're starting to use your bundle to render fairly complex forms using Symfony2's FormBuilder with Bootstrap.

What this pull request makes is that it renders any nested form label using `<legend>` instead of the usual `<label>` that Symfony2 uses, I think it improves the visibility a lot and [Bootstrap seems to do it that way](http://twitter.github.io/bootstrap/base-css.html#forms).

You can create a basic form with nested forms with this code:

```
$formBuilder = $this->createFormBuilder(array());
$formBuilder->add(
    $this->container->get('form.factory')->createNamedBuilder("section_1")
        ->add("name", "text", array("label" => "What is your name?"))
        ->add("number", "number", array("label" => "How old are you?"))
);
$formBuilder->add(
    $this->container->get('form.factory')->createNamedBuilder("section_2")
        ->add("comments", "textarea", array("label" => "What are your comments about the site?"))
);

$form = $formBuilder->getForm();
```

And it will render something like this:

![screenshot from 2013-05-12 22 53 41](https://f.cloud.github.com/assets/12800/493962/5f552e3a-bb7a-11e2-8c69-ef1784a624b4.png)

When looking at the code you'll see that I had to implement a `TypeExtension`; that is because there was no easy way to differentiate when it was a form being rendered and when it was another type of question. Had to google a lot to find out that [one of the Symfony2 devs suggested to do it this way](https://github.com/symfony/symfony/issues/5060#issuecomment-7273707).

Thanks for the awesome bundle :).
