### PR TITLE
Fixed rendering of integer, money, etc. inputs

### DIFF
--- a/Form/Extension/TypeSetterExtension.php
+++ b/Form/Extension/TypeSetterExtension.php
@@ -10,7 +10,7 @@ class TypeSetterExtension extends AbstractTypeExtension
 {
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['type'] = $form->getConfig()->getType()->getName();
+        $view->vars['original_type'] = $form->getConfig()->getType()->getName();
     }
 
     public function getExtendedType()

--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -348,7 +348,7 @@
     {% if label is empty %}
         {% set label = name|humanize %}
     {% endif %}
-    {% if type == 'form' %}
+    {% if original_type == 'form' %}
         <legend{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</legend>
     {% else %}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>


### PR DESCRIPTION
When I added the `<legend>` tag to the labels of nested forms (#46) I accidently broke the rendering of some other elements (money, integer, etc.). This pull request fixes that.

The reason it broke was because the view expected in these cases that the `type` variable didn't exist, so it could be set accordingly (`{{ set type = type|default('number') }}`).

To fix this I renamed the variable to `original_type`.
