### PR TITLE
Update form_div_layout.html.twig

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -496,6 +496,7 @@
         {{ form_label(form) }}
         <div class="controls">
             {{ form_widget(form) }}
+            {{ form_errors(form) }}
         </div>
     </div>
 {% endspaceless %}


### PR DESCRIPTION
No errors are shown when form_type is 'horizontal'. This commit will add the errors after the rendered input.
