### PR TITLE
Removed duplicated errors

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -496,7 +496,6 @@
         {{ form_label(form) }}
         <div class="controls">
             {{ form_widget(form) }}
-            {{ form_errors(form) }}
         </div>
     </div>
 {% endspaceless %}


### PR DESCRIPTION
Errors are already handled in form_widget (line 51). Errors are now shown twice.

In my previous commit, I seem to have confused client-side error handling (HTML5 required attribute) with server side error handling.
