### PR TITLE
Remove duplicate form_errors call

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -481,7 +481,6 @@
     {% else %}
         {{ form_label(form) }}
         {{ form_widget(form) }}
-        {{ form_errors(form) }}
     {% endif %}
 {% endspaceless %}
 {% endblock form_row %}


### PR DESCRIPTION
The form_widget call right above this form_errors call will always output the errors for the form whether its simple (line 51) or compound (line 119). This results in duplicate error messages.
