### PR TITLE
Update form_div_layout.html.twig with form_errors

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -495,6 +495,7 @@
         {{ form_label(form) }}
         <div class="controls">
             {{ form_widget(form) }}
+            {{ form_errors(form) }}
         </div>
     </div>
 {% endspaceless %}


### PR DESCRIPTION
I found the missing form_errors location. This solves my problem. Form errors are now output from anything. UniqueEntity or standard errors.

horizontal_row was missing a form_errors function.
