### PR TITLE
Fixing a collection delete button problems with removing items

### DIFF
--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -54,19 +54,11 @@
     };
 
     CollectionRemove.prototype.removeField = function (e) {
-        var $this = $(this),
-            selector = $this.attr('data-field'),
-            $parent
-        ;
-
-        $parent = $(selector);
+        var $this = $(this);
 
         e && e.preventDefault();
 
-        console.log($('#' + selector));
-        console.log($('#' + selector).parent());
-
-        var listElement = $('#' + selector).parent().remove();
+        var listElement = $this.closest('li').remove();
     }
 
 


### PR DESCRIPTION
There is a problem with removeField function in collection js file. A delete button requires additional n clicks (where n is the number of rows from entity) to delete a row. Not sure what was the cause but I tried a different removal approach and it works.
