### PR TITLE
Add wrapper div with validation classes to form_row when used without inline/horizontal options

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -479,8 +479,10 @@
     {% elseif form_type is defined and form_type == 'horizontal' %}
         {{ block('horizontal_row') }}
     {% else %}
+        <div class="control-group{% if errors|length %} error{% endif %}{% if validation_state is defined %} {{validation_state}}{% endif %}">
         {{ form_label(form) }}
         {{ form_widget(form) }}
+        </div>
     {% endif %}
 {% endspaceless %}
 {% endblock form_row %}


### PR DESCRIPTION
This fixes #70
