### PR TITLE
Add form_errors and wrapper with error classes to choice widgets

### DIFF
--- a/Resources/views/Form/form_div_layout.html.twig
+++ b/Resources/views/Form/form_div_layout.html.twig
@@ -169,11 +169,14 @@
 
 {% block choice_widget %}
 {% spaceless %}
-    {% if expanded %}
-        {{ block('choice_widget_expanded') }}
-    {% else %}
-        {{ block('choice_widget_collapsed') }}
-    {% endif %}
+      <div class="control-group{% if errors|length %} error{% endif %}{% if validation_state is defined %} {{validation_state}}{% endif %}">
+      {{ form_errors(form) }}
+      {% if expanded %}
+          {{ block('choice_widget_expanded') }}
+      {% else %}
+          {{ block('choice_widget_collapsed') }}
+      {% endif %}
+      </div>
 {% endspaceless %}
 {% endblock choice_widget %}
 


### PR DESCRIPTION
Choice widgets were not calling form_widget so form_errors were not being rendered. Added call to render form_errors and added wrapper div with validation classes.

Resolves #72
