### PR TITLE
Revised twitter bootstrap repo

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
             ->scalarNode('output_dir')->defaultValue('')->end()
-            ->scalarNode('assets_dir')->defaultValue('%kernel.root_dir%/../vendor/twitter/bootstrap')->end()
+            ->scalarNode('assets_dir')->defaultValue('%kernel.root_dir%/../vendor/twbs/bootstrap')->end()
             ->scalarNode('jquery_path')->defaultValue('%kernel.root_dir%/../vendor/jquery/jquery/jquery-1.9.1.js')->end()
             ->scalarNode('less_filter')
                 ->defaultValue('less')

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This bundle does no longer contain the asset files from Twitter Bootstrap (image
 
     {
        "require": {
-            "twitter/bootstrap": "2.3.*"
+            "twbs/bootstrap": "2.3.*"
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "knplabs/knp-paginator-bundle": "BraincraftedBootstrapBundle styles the pagination provided by KnpPaginatorBundle.",
         "knplabs/knp-menu":             "Required to use KnpMenuBundle.",
         "knplabs/knp-menu-bundle":      "BraincraftedBootstrapBundle styles the menus provided by KnpMenuBundle.",
-        "twitter/bootstrap":            "Twitter Bootstrap provides the assets (images, CSS and JS)"
+        "twbs/bootstrap":            "Twitter Bootstrap provides the assets (images, CSS and JS)"
     },
     "autoload": {
         "psr-0": { "Bc\\Bundle\\BootstrapBundle": "" }


### PR DESCRIPTION
Today Twitter have moved the Twitter Bootstrap Repository from twitter/botstrap to twbs/bootstrap on github. More info here: http://blog.getbootstrap.com/2013/07/27/bootstrap-3-rc1/
