### PR TITLE
Merge options.attr into listAttributes to allow for customizing with knp_menu_render

### DIFF
--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -22,7 +22,7 @@
     {% set options = options|merge({'currentClass': 'active'}) %}
 {% endif %}
 
-{% set listAttributes = item.childrenAttributes %}
+{% set listAttributes = item.childrenAttributes|merge(options.attr|default({})) %}
 {{ block('list') -}}
 {% endblock %}
 


### PR DESCRIPTION
If options.attr is provided, it will be merged into list.childrenAttributes, allowing you to override attributes on the wrapping element in a call to knp_menu_render.

Example:
{% set myMenu = knp_menu_get('myMenu', [], { foo: 'bar' }) %}
{{ knp_menu_render(myMenu, {
    attr: {
        title: 'My menu!!'
    }
}) }}
knp_menu_render(main
