### PR TITLE
Pills now work nicely and navbar-nav is excluded with pills / tabs.

### DIFF
--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -28,7 +28,7 @@
 
 {% block list %}
 {% if item.hasChildren and options.depth is not sameas(0) and item.displayChildren %}
-    {% set listAttributes = listAttributes|merge({'class': (listAttributes.class|default('') ~ ' nav navbar-nav')|trim}) %}
+    {% set listAttributes = listAttributes|merge({'class': (listAttributes.class|default('') ~ ' nav')|trim}) %}
 
     {% set listClass = '' %}
     {% if options.nav_type is defined and options.nav_type == 'tabs' %}
@@ -41,6 +41,8 @@
         {% set listClass = 'nav-pills nav-stacked' %}
     {% elseif options.nav_type is defined and options.nav_type == 'list' %}
         {% set listClass = 'nav-list' %}
+    {% else %}
+        {% set listClass = 'navbar-nav' %}
     {% endif %}
 
     {% if options.pull is defined and options.pull == 'right' %}


### PR DESCRIPTION
navbar-nav doesn't work nicely with nav-pills / nav-stacked. I'm not sure if this is the right way to implement it, but navbar-nav should be excluded when the menu is a tab / pill.
