### PR TITLE
Add icons to form buttons

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -475,7 +475,11 @@
     {% else %}
         {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-default')|trim }) %}
     {% endif %}
-    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans({}, translation_domain) }}</button>
+    {% if attr.icon is defined and attr.icon != '' %}
+        <button type="{{ type|default('button') }}" {{ block('button_attributes') }}><i class="{{ attr.icon }}"></i> {{ label|trans({}, translation_domain) }}</button>
+    {% else %}
+        <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ label|trans({}, translation_domain) }}</button>
+    {% endif %}
 {% endspaceless %}
 {% endblock button_widget %}
 


### PR DESCRIPTION
I don't really know how well to implement this better than I have done in this pull request, though I tested it and it would like a charm for me.

Usage:
In form class:

``` php
$builder->add('register', 'submit', array(
        'label' => 'Submit',
        'attr' => array(
          'icon' => 'fa fa-download'
        )
      ))
```

In my case I'm using FontAwesome and passed the class of the icon from the FontAwesome documentation to the `icon` attribute. I haven't tested with Glyphicons, but i guess it should work.
