### PR TITLE
Missing `type` variable which is unnecessary anyway

### DIFF
--- a/Resources/views/bootstrap.html.twig
+++ b/Resources/views/bootstrap.html.twig
@@ -125,7 +125,7 @@
         <div class="col-{{ col_size }}-{{ simple_col }}">
     {% endif %}
 
-    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}>
+    <input type="file" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}>
 
     {% if simple_col is defined %}
         </div>


### PR DESCRIPTION
When trying to render form with `file` element in it, there is an error:

> Variable "type" does not exist in /home/hsz/projects/MyProject/vendor/braincrafted/bootstrap-bundle/Braincrafted/Bundle/BootstrapBundle/Resources/views/Form/bootstrap.html.twig at line 159

`file_widget` block uses `type` variable, which does not exist. However we can hardcode it to `file` because we are generating `input[type=file]`.
