### PR TITLE
Added types for badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /composer.lock
 *.sublime-project
 *.sublime-workspace
+*~

--- a/Tests/Twig/BootstrapBadgeExtensionTest.php
+++ b/Tests/Twig/BootstrapBadgeExtensionTest.php
@@ -57,6 +57,36 @@ class BootstrapBadgeExtensionTest extends \PHPUnit_Framework_TestCase
             $this->extension->badgeFunction('Hello World'),
             '->badgeFunction() returns the HTML code for the given badge.'
         );
+        
+        $this->assertEquals(
+            '<span class="badge badge-primary">Hello World</span>',
+            $this->extension->badgeFunction('Hello World', 'primary'),
+            '->badgeFunction() returns the HTML code for the given badge.'
+        );
+        
+        $this->assertEquals(
+            '<span class="badge badge-success">Hello World</span>',
+            $this->extension->badgeFunction('Hello World', 'success'),
+            '->badgeFunction() returns the HTML code for the given badge.'
+        );
+        
+        $this->assertEquals(
+            '<span class="badge badge-info">Hello World</span>',
+            $this->extension->badgeFunction('Hello World', 'info'),
+            '->badgeFunction() returns the HTML code for the given badge.'
+        );
+        
+        $this->assertEquals(
+            '<span class="badge badge-warning">Hello World</span>',
+            $this->extension->badgeFunction('Hello World', 'warning'),
+            '->badgeFunction() returns the HTML code for the given badge.'
+        );
+        
+        $this->assertEquals(
+            '<span class="badge badge-danger">Hello World</span>',
+            $this->extension->badgeFunction('Hello World', 'danger'),
+            '->badgeFunction() returns the HTML code for the given badge.'
+        );
     }
 
     /**

--- a/Twig/BootstrapBadgeExtension.php
+++ b/Twig/BootstrapBadgeExtension.php
@@ -41,12 +41,17 @@ class BootstrapBadgeExtension extends Twig_Extension
      * Returns the HTML code for a badge.
      *
      * @param string $text The text of the badge
+     * @param string $type The type of badge
      *
      * @return string The HTML code of the badge
      */
-    public function badgeFunction($text)
+    public function badgeFunction($text, $type = NULL)
     {
-        return sprintf('<span class="badge">%s</span>', $text);
+        if ($type) {
+            $type = ' badge-'.$type;
+        }
+
+        return sprintf('<span class="badge%s">%s</span>', $type, $text);
     }
 
     /**


### PR DESCRIPTION
I've added type parameter to badge twig function:

{{ badge('10') }}
{{ badge('10', 'primary') }}
{{ badge('10', 'success') }}
{{ badge('10', 'info') }}
{{ badge('10', 'warning') }}
{{ badge('10', 'danger') }}
