### PR TITLE
[Proposal] Allow HTML in input Prepend

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -620,11 +620,11 @@
         {% endif  %}
         <div class="input-group{{ ig_size_class }}">
             {% if input_group.prepend is defined and input_group.prepend is not empty %}
-                <span class="input-group-addon">{{ input_group.prepend }}</span>
+                <span class="input-group-addon">{{ input_group.prepend|raw }}</span>
             {% endif %}
             {{ form_widget(form) }}
             {% if input_group.append is defined and input_group.append is not empty %}
-                <span class="input-group-addon">{{ input_group.append }}</span>
+                <span class="input-group-addon">{{ input_group.append|raw }}</span>
             {% endif %}
         </div>
     {% else %}


### PR DESCRIPTION
Currently the only thing you can prepend or append to fields is plain text, since any HTML is escaped once its printed by twig.

This does not allow us to use icons in prepends and appends, which is totally supported by bootstrap by adding the html: `<i class="icon-class"></i>`

Adding a `|raw` does the trick. As far as i can forsee it will not break anything else, unless someone is passing in `<html>` and expecting to see that as text. Using escape chars would do the trick in that case.

Is this a good solution? Or would you rather we add a 'raw' option that can cause `|raw` to be added or not?
