### PR TITLE
Removed appending nav class to list childs

### DIFF
--- a/Resources/views/Menu/bootstrap.html.twig
+++ b/Resources/views/Menu/bootstrap.html.twig
@@ -29,7 +29,7 @@
 
 {% block list %}
 {% if item.hasChildren and options.depth is not sameas(0) and item.displayChildren %}
-    {% set listAttributes = listAttributes|merge({'class': (listAttributes.class|default('') ~ ' nav')|trim}) %}
+    {% set listAttributes = listAttributes|merge({'class': listAttributes.class|default('')|trim}) %}
 
     {% set listClass = '' %}
     {% if options.style is defined and options.style == 'tabs' %}


### PR DESCRIPTION
The nav class on children gives weird padding on them (bootstrap 3), should only be used on root level element.
