### PR TITLE
btn-primary is not always welcome for submit

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -477,9 +477,9 @@
         {% set label = name|humanize %}
     {% endif %}
     {% if type is defined and type == 'submit' %}
-        {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-primary')|trim }) %}
+        {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~attr.type|default('primary'))|trim }) %}
     {% else %}
-        {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-default')|trim }) %}
+        {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~attr.type|default('default'))|trim }) %}
     {% endif %}
     <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</button>
 {% endspaceless %}


### PR DESCRIPTION
I use symfony's crud generator. It generates separate delete form. So the problem is that it submit button has <code>btn-primary</code> class. Even when I put <code>btn-danger</code> class as attribute in form creation, the button has both <code>btn-primary</code> and <code>btn-danger</code> classes. And unfortunately primary class is accepted. It comes from <a href="https://github.com/braincrafted/bootstrap-bundle/blob/develop/Resources/views/Form/bootstrap.html.twig#L480">here</a>. Should I just override it? Or there is more elegant solution?
