### PR TITLE
Add symfony-bin-dir (bin/console) support - FIXES: #245,#246.

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -33,7 +33,7 @@ class ScriptHandler
     public static function install(CommandEvent $event)
     {
         $options = self::getOptions($event);
-        $consolePathOptionsKey = array_key_exists($options, 'symfony-bin-dir') ? 'symfony-bin-dir' : 'symfony-app-dir'; 
+        $consolePathOptionsKey = array_key_exists('symfony-bin-dir', $options) ? 'symfony-bin-dir' : 'symfony-app-dir'; 
         $consolePath = $options[$consolePathOptionsKey];
 
         if (!is_dir($consolePath)) {


### PR DESCRIPTION
Quickly added `symfony-bin-dir` support. Hope that helps prevent further issues.

It's basically a simplified version of [sstok's implementation](https://github.com/sstok/SpBowerBundle/commit/a82fcb4badf6f560482b274f3a7c267d47b5c92c) for SpBowerBundle.

The `symfony-bin-dir` key gets added in SensioDistributionBundle's [`ScriptHandler::defineDirectoryStructure`](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L53).
