### PR TITLE
Add nav class based on depth not parent

### DIFF
--- a/Resources/views/Menu/bootstrap.html.twig
+++ b/Resources/views/Menu/bootstrap.html.twig
@@ -60,7 +60,7 @@
         {% set listClass = (listClass|default('') ~ 'pull-left')|trim %}
     {% endif %}
     
-    {% set listClass = (item.parent is null) ? listClass ~ ' nav' : listClass %}
+    {% set listClass = (options.currentDepth == 0) ? listClass ~ ' nav' : listClass %}
 
     {% set listAttributes = listAttributes|merge({'class': (listAttributes.class|default('') ~ ' ' ~ listClass)|trim}) %}
 


### PR DESCRIPTION
The nav class should be added when the current depth is 0, meaning when the item is the first to be rendered. The previous way checked if the item had a parent. But this would screw up rendering if the user wanted to render just a subset of the tree, because that item would always have a parent but should be rendered with the nav class.
