### PR TITLE
Fixing placeholder application in inline forms

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -37,7 +37,7 @@
     {% set type = type|default('text') %}
     {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' form-control')|trim }) %}
 
-    {% if style == 'inline' and (attr.placeholder is not defined or attr.placeholder is empty) %}
+    {% if style == 'inline' and (attr.placeholder is not defined or attr.placeholder is empty)  and label != false %}
         {% if label is empty %}
             {% set attr = attr|merge({ 'placeholder': name|humanize }) %}
         {% else %}


### PR DESCRIPTION
The current code triggers `label => false` in `inline` forms to use `name|humanize` as the placeholder.
This is wrong and if label is set explicitly to `false` it should trigger no placeholder.

This fix adds the extra check to avoid this behavior.

Should this be applied to any other branches?
