### PR TITLE
Remove whitespace in root block

### DIFF
--- a/Resources/views/Menu/bootstrap.html.twig
+++ b/Resources/views/Menu/bootstrap.html.twig
@@ -24,7 +24,6 @@
     {% set options = options|merge({'currentClass': 'active'}) %}
     {% set options = options|merge({'ancestorClass': 'active'}) %}
 {% endif %}
-
 {% set listAttributes = item.childrenAttributes %}
 {{ block('list') -}}
 {% endblock %}


### PR DESCRIPTION
This PR removes some unnecessary whitespace in the Menu twig template.

In the root block it's important to have no whitespace if the menu is empty, so that you can check if a block must be rendered.

e.g. you can do

```
{% set _my_meny    = block('my_menu') %}
{% if _my_menu is not empty %}
    <div class="my-meny">
        {{ _my_menu|raw }}
    </div>
{% endif %}
```
