### PR TITLE
Check for "false" label

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -495,7 +495,7 @@
 
 {% block button_widget %}
     {% spaceless %}
-        {% if label is empty %}
+        {% if label is empty and label != false %}
             {% set label = name|humanize %}
         {% endif %}
         {% if type is defined and type == 'submit' %}


### PR DESCRIPTION
Another instance of a label not checked for `false` this forcing a default value on it.
this fix makes false labels be left alone.
