### PR TITLE
Check for "false" label

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -495,7 +495,7 @@
 
 {% block button_widget %}
     {% spaceless %}
-        {% if label is empty %}
+        {% if label is empty and label is not sameas(false) %}
             {% set label = name|humanize %}
         {% endif %}
         {% if type is defined and type == 'submit' %}


### PR DESCRIPTION
Doing a proper check using `sameas`, since twig `!=` does a weak check.

This allows false labels in buttons, for rendering icon only buttons for example.
