### PR TITLE
Updated Default JQuery Path

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
     const DEFAULT_BOOTSTRAP_TEMPLATE_SASS = 'BraincraftedBootstrapBundle:Bootstrap:bootstrap.scss.twig';
 
     /** @var string */
-    const DEFAULT_JQUERY_PATH = '%kernel.root_dir%/../vendor/jquery/jquery/jquery-1.11.0.js';
+    const DEFAULT_JQUERY_PATH = '%kernel.root_dir%/../vendor/jquery/jquery/jquery-1.11.1.js';
 
     /** @var string */
     const DEFAULT_FONTS_DIR = '%kernel.root_dir%/../web/fonts';


### PR DESCRIPTION
The defaut jQuery path should link to the current version of jQuery, which is `1.11.1` and not `1.11.0`. Otherwise, I get the following error when I do a `php app/console assetic:dump`:

```
[RuntimeException]                                                                                
The source file "/var/www/roombook/app/../vendor/jquery/jquery/jquery-1.11.0.js" does not exist.
```
