### PR TITLE
Allow translation of form error messages

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -818,7 +818,7 @@
             {% endif %}
             <ul{% if not global_errors %} class="help-block"{% endif %}>
                 {% for error in errors %}
-                    <li>{{ error.message }}</li>
+                    <li>{{ error.message|trans }}</li>
                 {% endfor %}
             </ul>
             {% if global_errors == true %}


### PR DESCRIPTION
This change would allow the translation of form error messages, such as the "Bad credentials" message in a login form.
