### PR TITLE
Fixed conflict with BS error class (fixes #263)

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -736,7 +736,7 @@
         {% endif %}
 
         {% if form.vars.errors|length > 0 %}
-            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' has-error')|trim }) %}
+            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' has-global-errors')|trim }) %}
         {% endif %}
 
         {% if col_size is defined %}


### PR DESCRIPTION
Renamed the error class added for global errors as this conflicts with BS error rendering. See #263 for details.
