### PR TITLE
bootstrap-collection

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -874,7 +874,7 @@
 {% block widget_container_attributes %}
     {% spaceless %}
         {% if attr.style is defined and (attr.style == 'inline' or attr.style == 'horizontal') %}
-            {% set attr = attr|merge({ 'class': 'form-'~attr.style~attr.class|default('') }) %}
+            {% set attr = attr|merge({ 'class': ('form-'~attr.style~' '~attr.class|default(''))|trim }) %}
             {% set attr = attr|merge({ 'style': null }) %}
         {% endif %}
         {% if id is not empty %}id="{{ id }}" {% endif %}


### PR DESCRIPTION
In a "bootstrap-collection", if you set an attr "style" and "class", the class style and the "class" attr will be stuck without space
