### PR TITLE
Add help text to single checkbox and radio

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -283,6 +283,8 @@
             <div class="checkbox">{{ checkboxdata|raw }}</div>
         {% endif %}
 
+        {{ block('form_help') }}
+
         {% if align_with_widget is defined or attr.align_with_widget is defined %}
             </div>
             </div>
@@ -350,6 +352,7 @@
             <div class="radio">{{ radiodata|raw }}</div>
         {% endif %}
 
+        {{ block('form_help') }}
 
         {% if align_with_widget is defined or attr.align_with_widget is defined %}
             </div>


### PR DESCRIPTION
Help text is not rendered under single checkbox and single radio. Example form builder:

```
$builder->add('gender', 'choice', array(
    'choices'   => array('m' => 'Male', 'f' => 'Female'),
    'multiple' => false,
    'expanded' => true,
    'required'  => true,
    'mapped' => false,
    'attr' => array(
        'help_text' => 'Who are you?'
    )
))
->add('newsletter', 'checkbox', array(
    'mapped' => false,
    'attr' => array(
        'align_with_widget' => true,
        'help_text' => 'Would you like to receive our newsletter?'
    )
))
```

renders:
![image](https://cloud.githubusercontent.com/assets/4865922/3604684/ce479c06-0d22-11e4-9276-993c1321c5d6.png)

With the patch:
![image](https://cloud.githubusercontent.com/assets/4865922/3604696/f806c44a-0d22-11e4-9f17-cc0251298aec.png)
