### PR TITLE
Form actions patch

### DIFF
--- a/Form/Extension/ButtonTypeExtension.php
+++ b/Form/Extension/ButtonTypeExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Braincrafted\Bundle\BootstrapBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * FormControlStaticType
+ *
+ * @package    BraincraftedBootstrapBundle
+ * @subpackage Form
+ * @author     André Püschel <pue@der-pue.de>
+ * @copyright  2014 André Püschel
+ * @license    http://opensource.org/licenses/MIT The MIT License
+ * @link       http://bootstrap.braincrafted.com Bootstrap for Symfony2
+ */
+class ButtonTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['button_class'] = $form->getConfig()->getOption('button_class');
+        $view->vars['as_link'] = $form->getConfig()->getOption('as_link');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setOptional(array('button_class', 'as_link'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'button';
+    }
+}

--- a/Resources/config/services/form.xml
+++ b/Resources/config/services/form.xml
@@ -8,6 +8,7 @@
         <parameter key="braincrafted_bootstrap.form.type.money.class">Braincrafted\Bundle\BootstrapBundle\Form\Type\MoneyType</parameter>
         <parameter key="braincrafted_bootstrap.form.type.form_actions.class">Braincrafted\Bundle\BootstrapBundle\Form\Type\FormActionsType</parameter>
         <parameter key="braincrafted_bootstrap.form.extension.typesetter_extension.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\TypeSetterExtension</parameter>
+        <parameter key="braincrafted_bootstrap.form.extension.button_extension.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\ButtonTypeExtension</parameter>
         <parameter key="braincrafted_bootstrap.form.extension.input_group_button.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\InputGroupButtonExtension</parameter>
     </parameters>
 
@@ -27,6 +28,10 @@
 
         <service id="braincrafted_bootstrap.form.extension.typesetter_extension" class="%braincrafted_bootstrap.form.extension.typesetter_extension.class%">
             <tag name="form.type_extension" alias="form" />
+        </service>
+
+        <service id="braincrafted_bootstrap.form.extension.form_action_button" class="%braincrafted_bootstrap.form.extension.button_extension.class%">
+            <tag name="form.type_extension" alias="button" />
         </service>
 
         <service id="braincrafted_bootstrap.form.extension.input_group_button" class="%braincrafted_bootstrap.form.extension.input_group_button.class%">

--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -502,11 +502,15 @@
             {% set label = name|humanize %}
         {% endif %}
         {% if type is defined and type == 'submit' %}
-            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~attr.type|default('primary'))|trim }) %}
+            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~button_class|default('primary'))|trim }) %}
         {% else %}
-            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~attr.type|default('default'))|trim }) %}
+            {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~button_class|default('default'))|trim }) %}
         {% endif %}
-        <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</button>
+        {% if as_link is defined and as_link == true %}
+            <a {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</a>
+        {% else %}
+            <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</button>
+        {% endif %}
     {% endspaceless %}
 {% endblock button_widget %}
 


### PR DESCRIPTION
Currently to get different coloured buttons you had to have a something like `"type" => "danger"`in the `attr` array. Since all entries in attr are rendered into markup in `button_attributes` block, you end up with two `type` attributes in your markup.
This ButtonExtension introduces a new option `buttonclass` for that purpose.
In addition it also provides the possibility to render an `<a>`-tag as BS-styled button using the option `"asatag" => true` and having the `href` in the `attr` array.
