### PR TITLE
Input Group Button Support

### DIFF
--- a/Form/Extension/InputGroupButtonExtension.php
+++ b/Form/Extension/InputGroupButtonExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 
-class InputGroupBtnExtension extends AbstractTypeExtension
+class InputGroupButtonExtension extends AbstractTypeExtension
 {
     /**
      * @var ButtonBuilder
@@ -36,11 +36,11 @@ class InputGroupBtnExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if ($this->prependedButtonBuilder !== null) {
-            $view->vars['input_group_btn_prepend'] = $this->prependedButtonBuilder->getForm()->createView();
+            $view->vars['input_group_button_prepend'] = $this->prependedButtonBuilder->getForm()->createView();
         }
 
         if ($this->appendedButtonBuilder !== null) {
-            $view->vars['input_group_btn_append'] = $this->appendedButtonBuilder->getForm()->createView();
+            $view->vars['input_group_button_append'] = $this->appendedButtonBuilder->getForm()->createView();
         }
     }
 
@@ -53,13 +53,19 @@ class InputGroupBtnExtension extends AbstractTypeExtension
             return;
         }
 
-        if (isset($options['attr']['input_group']['btn_prepend'])) {
-            $this->prependedButtonBuilder = $this->addButton($builder, $options['attr']['input_group']['btn_prepend']);
+        if (isset($options['attr']['input_group']['button_prepend'])) {
+            $this->prependedButtonBuilder = $this->addButton(
+                $builder,
+                $options['attr']['input_group']['button_prepend']
+            );
         }
 
 
-        if (isset($options['attr']['input_group']['btn_append'])) {
-            $this->appendedButtonBuilder = $this->addButton($builder, $options['attr']['input_group']['btn_append']);
+        if (isset($options['attr']['input_group']['button_append'])) {
+            $this->appendedButtonBuilder = $this->addButton(
+                $builder,
+                $options['attr']['input_group']['button_append']
+            );
         }
 
     }

--- a/Resources/config/services/form.xml
+++ b/Resources/config/services/form.xml
@@ -8,7 +8,7 @@
         <parameter key="braincrafted_bootstrap.form.type.money.class">Braincrafted\Bundle\BootstrapBundle\Form\Type\MoneyType</parameter>
         <parameter key="braincrafted_bootstrap.form.type.form_actions.class">Braincrafted\Bundle\BootstrapBundle\Form\Type\FormActionsType</parameter>
         <parameter key="braincrafted_bootstrap.form.extension.typesetter_extension.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\TypeSetterExtension</parameter>
-        <parameter key="braincrafted_bootstrap.form.extension.input_group_btn.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\InputGroupBtnExtension</parameter>
+        <parameter key="braincrafted_bootstrap.form.extension.input_group_button.class">Braincrafted\Bundle\BootstrapBundle\Form\Extension\InputGroupButtonExtension</parameter>
     </parameters>
 
     <services>
@@ -29,7 +29,7 @@
             <tag name="form.type_extension" alias="form" />
         </service>
 
-        <service id="braincrafted_bootstrap.form.extension.input_group_btn" class="%braincrafted_bootstrap.form.extension.input_group_btn.class%">
+        <service id="braincrafted_bootstrap.form.extension.input_group_button" class="%braincrafted_bootstrap.form.extension.input_group_button.class%">
             <tag name="form.type_extension" alias="text" />
         </service>
 

--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -651,12 +651,12 @@
                 {% if input_group.prepend is defined and input_group.prepend is not empty %}
                     <span class="input-group-addon">{{ input_group.prepend|raw|parse_icons }}</span>
                 {% endif %}
-                {% if input_group.btn_prepend is defined and input_group.btn_prepend is not empty %}
-                    <span class="input-group-btn">{{ form_widget(input_group_btn_prepend) }}</span>
+                {% if input_group.button_prepend is defined and input_group.button_prepend is not empty %}
+                    <span class="input-group-btn">{{ form_widget(input_group_button_prepend) }}</span>
                 {% endif %}
                 {{ form_widget(form) }}
-                {% if input_group.btn_append is defined and input_group.btn_append is not empty %}
-                    <span class="input-group-btn">{{ form_widget(input_group_btn_append) }}</span>
+                {% if input_group.button_append is defined and input_group.button_append is not empty %}
+                    <span class="input-group-btn">{{ form_widget(input_group_button_append) }}</span>
                 {% endif %}
                 {% if input_group.append is defined and input_group.append is not empty %}
                     <span class="input-group-addon">{{ input_group.append|raw|parse_icons }}</span>

--- a/Tests/Form/Extension/InputGroupButtonExtensionTest.php
+++ b/Tests/Form/Extension/InputGroupButtonExtensionTest.php
@@ -4,13 +4,13 @@
 namespace Braincrafted\Bundle\BootstrapBundle\Tests\Form\Extension;
 
 use \Mockery as m;
-use Braincrafted\Bundle\BootstrapBundle\Form\Extension\InputGroupBtnExtension;
+use Braincrafted\Bundle\BootstrapBundle\Form\Extension\InputGroupButtonExtension;
 use Symfony\Component\Form\FormView;
 
-class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
+class InputGroupButtonExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var InputGroupBtnExtension
+     * @var InputGroupButtonExtension
      */
     private $extension;
 
@@ -19,7 +19,7 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->extension = new InputGroupBtnExtension();
+        $this->extension = new InputGroupButtonExtension();
     }
 
     public function testBuildView()
@@ -27,8 +27,8 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
         $optionsBoth = array(
             'attr' => array(
                 'input_group' => array(
-                    'btn_prepend' => array('name' => 'prepend', 'type' => 'submit', 'options' => array()),
-                    'btn_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
+                    'button_prepend' => array('name' => 'prepend', 'type' => 'submit', 'options' => array()),
+                    'button_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
                 )
             ),
         );
@@ -56,10 +56,10 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->extension->buildView($view, $type, array());
 
-        $this->assertArrayHasKey('input_group_btn_prepend', $view->vars);
-        $this->assertArrayHasKey('input_group_btn_append', $view->vars);
-        $this->assertEquals('prepend', $view->vars['input_group_btn_prepend']);
-        $this->assertEquals('append', $view->vars['input_group_btn_append']);
+        $this->assertArrayHasKey('input_group_button_prepend', $view->vars);
+        $this->assertArrayHasKey('input_group_button_append', $view->vars);
+        $this->assertEquals('prepend', $view->vars['input_group_button_prepend']);
+        $this->assertEquals('append', $view->vars['input_group_button_append']);
     }
 
     /**
@@ -70,11 +70,11 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $builder = m::mock('Symfony\Component\Form\FormBuilderInterface');
 
-        if (isset($options['attr']['input_group']['btn_prepend'])) {
+        if (isset($options['attr']['input_group']['button_prepend'])) {
             $builder->shouldReceive('create')->with('prepend', 'submit', array())->once();
         }
 
-        if (isset($options['attr']['input_group']['btn_append'])) {
+        if (isset($options['attr']['input_group']['button_append'])) {
             $builder->shouldReceive('create')->with('append', 'submit', array())->once();
         }
 
@@ -86,8 +86,8 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
         $optionsBoth = array(
             'attr' => array(
                 'input_group' => array(
-                    'btn_prepend' => array('name' => 'prepend', 'type' => 'submit', 'options' => array()),
-                    'btn_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
+                    'button_prepend' => array('name' => 'prepend', 'type' => 'submit', 'options' => array()),
+                    'button_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
                 )
             ),
         );
@@ -95,7 +95,7 @@ class InputGroupBtnExtensionTest extends \PHPUnit_Framework_TestCase
         $optionsOne = array(
             'attr' => array(
                 'input_group' => array(
-                    'btn_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
+                    'button_append' => array('name' => 'append', 'type' => 'submit', 'options' => array())
                 )
             ),
         );


### PR DESCRIPTION
Added a new Extension to allow people to append buttons to inputs as well as
icons. Will add examples to the docs repo also. But this is what it looks
like:

```
$builder
           ->add('keywords', 'text', [
                   'label' => false,
                   'attr' => array(
                       'input_group' => array(
                           'button_append' => ['name' => 'search', 'type' =>
'submit']
                       )
                   )
               ]);
```

This closes #250.
