### PR TITLE
Removed trailing whitespace for checkbox and radio

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -269,7 +269,7 @@
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ block('checkbox_widget') }}
-            {{ label|trans({}, translation_domain)|raw }}
+            {{ label|trans({}, translation_domain)|raw -}}
             </label>
         {% else %}
             {{ block('checkbox_widget') }}
@@ -338,7 +338,7 @@
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ block('radio_widget') }}
-            {{ label|trans({}, translation_domain)|raw }}
+            {{ label|trans({}, translation_domain)|raw -}}
             </label>
         {% else %}
             {{ block('radio_widget') }}


### PR DESCRIPTION
The newline after the label variable output in the twig template, added unwanted vertical height to the rendered label tag in the browser.
