### PR TITLE
Translating Error Messages

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -830,7 +830,7 @@
             {% endif %}
             <ul{% if not global_errors %} class="help-block"{% endif %}>
                 {% for error in errors %}
-                    <li>{{ error.message }}</li>
+                    <li>{{ error.message|trans }}</li>
                 {% endfor %}
             </ul>
             {% if global_errors == true %}


### PR DESCRIPTION
Without this call to `trans` the custom error messages are not translated, only the proper built-in ones.
