### PR TITLE
Fix nested subform settings

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -748,6 +748,7 @@
 
 {% block form_start %}
     {% spaceless %}
+        {{ bootstrap_backup_form_settings() }}
         {% set method = method|upper %}
         {% if method in ["GET", "POST"] %}
             {% set form_method = method %}
@@ -812,6 +813,7 @@
         {% if bootstrap_get_simple_col() %}
             {{ bootstrap_set_simple_col(false) }}
         {% endif %}
+    {{ bootstrap_restore_form_settings() }}
     {% endspaceless %}
 {% endblock form_end %}
 

--- a/Tests/Twig/BootstrapFormExtensionTest.php
+++ b/Tests/Twig/BootstrapFormExtensionTest.php
@@ -44,7 +44,7 @@ class BootstrapFormExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFunctions()
     {
-        $this->assertCount(14, $this->extension->getFunctions());
+        $this->assertCount(16, $this->extension->getFunctions());
     }
 
     /**
@@ -95,6 +95,41 @@ class BootstrapFormExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->extension->setSimpleCol(8);
         $this->assertEquals(8, $this->extension->getSimpleCol());
+    }
+
+    /**
+     * @covers Braincrafted\Bundle\BootstrapBundle\Twig\BootstrapFormExtension::backupFormSettings()
+     * @covers Braincrafted\Bundle\BootstrapBundle\Twig\BootstrapFormExtension::restoreFormSettings()
+     */
+    public function testBackupFormSettingsRestoreFormSettings()
+    {
+        $this->extension->setStyle('horizontal');
+        $this->extension->setColSize('sm');
+        $this->extension->setWidgetCol(1);
+        $this->extension->setLabelCol(2);
+        $this->extension->setSimpleCol(3);
+
+        $this->extension->backupFormSettings();
+
+        $this->extension->setStyle('inline');
+        $this->extension->setColSize('lg');
+        $this->extension->setWidgetCol(4);
+        $this->extension->setLabelCol(5);
+        $this->extension->setSimpleCol(6);
+
+        $this->extension->restoreFormSettings();
+
+        $this->assertEquals('horizontal', $this->extension->getStyle());
+        $this->assertEquals('sm', $this->extension->getColSize());
+        $this->assertEquals(1, $this->extension->getWidgetCol());
+        $this->assertEquals(2, $this->extension->getLabelCol());
+        $this->assertEquals(3, $this->extension->getSimpleCol());
+
+        try {
+            $this->extension->restoreFormSettings();
+            $this->fail('Expected UnderflowException not thrown');
+        } catch (\UnderflowException $e) {
+        }
     }
 
     /**

--- a/Twig/BootstrapFormExtension.php
+++ b/Twig/BootstrapFormExtension.php
@@ -33,6 +33,9 @@ class BootstrapFormExtension extends \Twig_Extension
     /** @var integer */
     private $simpleCol = false;
 
+    /** @var array */
+    private $settingsStack = array();
+
     /**
      * {@inheritdoc}
      */
@@ -49,6 +52,8 @@ class BootstrapFormExtension extends \Twig_Extension
             new \Twig_SimpleFunction('bootstrap_get_label_col', array($this, 'getLabelCol')),
             new \Twig_SimpleFunction('bootstrap_set_simple_col', array($this, 'setSimpleCol')),
             new \Twig_SimpleFunction('bootstrap_get_simple_col', array($this, 'getSimpleCol')),
+            new \Twig_SimpleFunction('bootstrap_backup_form_settings', array($this, 'backupFormSettings')),
+            new \Twig_SimpleFunction('bootstrap_restore_form_settings', array($this, 'restoreFormSettings')),
             'checkbox_row'  => new \Twig_Function_Node(
                 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
                 array('is_safe' => array('html'))
@@ -175,6 +180,48 @@ class BootstrapFormExtension extends \Twig_Extension
     public function getSimpleCol()
     {
         return $this->simpleCol;
+    }
+
+    /**
+     * Backup the form settings to the stack.
+     *
+     * @internal Should only be used at the beginning of form_start. This allows
+     *           a nested subform to change its settings without affecting its
+     *           parent form.
+     */
+    public function backupFormSettings()
+    {
+        $settings = array(
+            'style'     => $this->style,
+            'colSize'   => $this->colSize,
+            'widgetCol' => $this->widgetCol,
+            'labelCol'  => $this->labelCol,
+            'simpleCol' => $this->simpleCol,
+        );
+
+        array_push($this->settingsStack, $settings);
+    }
+
+    /**
+     * Restore the form settings from the stack.
+     *
+     * @internal Should only be used at the end of form_end.
+     * @see backupFormSettings
+     * @throws \UnderflowException
+     */
+    public function restoreFormSettings()
+    {
+        if (count($this->settingsStack) < 1) {
+            throw new \UnderflowException("No settings on the stack to restore");
+        }
+
+        $settings = array_pop($this->settingsStack);
+
+        $this->style     = $settings['style'];
+        $this->colSize   = $settings['colSize'];
+        $this->widgetCol = $settings['widgetCol'];
+        $this->labelCol  = $settings['labelCol'];
+        $this->simpleCol = $settings['simpleCol'];
     }
 
     public function formControlStaticFunction($label, $value)


### PR DESCRIPTION
Form settings were not being maintained when subforms are involved. If a subform changed a form setting, the parent form would inherit the new value from the subform after the subform was rendered.

I'm assuming the reverse-inheritance wasn't an intended behavior. This patch saves and restores form settings as a stack so that parent forms have their original state after a subform ends.
