### PR TITLE
wrap input-groups in a label so they're clickable

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -660,7 +660,7 @@
             {% if input_group.size is defined and input_group.size == 'small' %}
                 {% set ig_size_class = ' input-group-sm' %}
             {% endif  %}
-            <div class="input-group{{ ig_size_class }}">
+            <label class="input-group{{ ig_size_class }}">
                 {% if input_group.prepend is defined and input_group.prepend is not empty %}
                     <span class="input-group-addon">{{ input_group.prepend|raw|parse_icons }}</span>
                 {% endif %}
@@ -674,7 +674,7 @@
                 {% if input_group.append is defined and input_group.append is not empty %}
                     <span class="input-group-addon">{{ input_group.append|raw|parse_icons }}</span>
                 {% endif %}
-            </div>
+            </label>
         {% else %}
             {{ form_widget(form) }}
         {% endif %}


### PR DESCRIPTION
This makes clicking an `.input-group-addon` focus the field by wrapping the `.input-group` in a `<label>`.

No `for="name"` attribute is required since the input is contained within the `<label></label>`.

However, there's no example like this in the bootstrap docs so I'm not sure if you want this or if it should just live in my template overrides.
