### PR TITLE
wrap labels in column div so the surrounding whitespace isn't clickable

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -569,7 +569,8 @@
 
             {% set label_attr = label_attr|merge({ 'class': (label_attr.class|default('') ~ ' control-label')|trim }) %}
             {% if style == 'horizontal' %}
-                {% set label_attr = label_attr|merge({ 'class': (label_attr.class|default('') ~ ' col-' ~ col_size ~ '-' ~ label_col)|trim }) %}
+                {% set label_attr = label_attr|merge({ 'class': (label_attr.class|default('') ~ ' pull-right')|trim }) %}
+                {% set label_container_attr = { 'class': ('col-' ~ col_size ~ '-' ~ label_col) } %}
             {% elseif style == 'inline' %}
                 {% set label_attr = label_attr|merge({ 'class': (label_attr.class|default('') ~ ' sr-only')|trim }) %}
             {% endif %}
@@ -583,7 +584,14 @@
             {% if label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain)|raw }}</label>
+
+            {% if label_container_attr is defined %}
+                <div{% for attrname, attrvalue in label_container_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {% endif %}
+                    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain)|raw }}</label>
+            {% if label_container_attr is defined %}
+                </div>
+            {% endif %}
         {% endif %}
     {% endspaceless %}
 {% endblock form_label %}


### PR DESCRIPTION
This uses a `<div>` wrapper around horizontal labels and puts the column class on the `<div>` instead of the `<label>`. The purpose is to prevent large areas of whitespace to the left of the label text from being clickable parts of the label. I add `.pull-right` to the label so it draws in the same location as before.

This is another one that does not appear in the bootstrap docs. Don't know what your philosophy is on that, it might also need to just live in my overrides instead.

I just get really bothered when I click what appears to be the page margin and it takes some kind of action when all I wanted to do was focus the window so I can scroll, etc. Reminds me of pages that make the whole margin an advertisement link.
