### PR TITLE
Removed invalid statement

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -182,7 +182,7 @@
     {% spaceless %}
         <div {{ block('widget_container_attributes') }}>
             {% for child in form %}
-                {% if form.multiple is defined %}
+                {% if multiple %}
                     {{ checkbox_row(child, { 'no_form_group': true, 'inline' : (attr.inline is defined and attr.inline), 'label_attr': label_attr }) }}
                 {% else %}
                     {{ radio_row(child, { 'no_form_group': true, 'inline' : (attr.inline is defined and attr.inline), 'label_attr': label_attr  }) }}


### PR DESCRIPTION
Actually the else statement was always called but rendered a radio or checkbox widget anyway, so that the differentiation can be considered redundant (but perhaps useful for extensions)
