### PR TITLE
Added support for the new `label_format` option

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -517,13 +517,15 @@
 
 {% block button_widget %}
     {% spaceless %}
-        {% if label_format is defined and label_format is not empty and label is not sameas(false) %}
-            {% set label = label_format|replace({
-                '%name%': name,
-                '%id%': id,
-            }) %}
-        {% elseif label is empty and label is not sameas(false) %}
-            {% set label = name|humanize %}
+        {% if label is not sameas(false) %}
+            {% if label_format is defined and label_format is not empty %}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {% elseif label is empty %}
+                {% set label = name|humanize %}
+            {% endif %}
         {% endif %}
         {% if type is defined and type == 'submit' %}
             {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~button_class|default('primary'))|trim }) %}

--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -37,11 +37,16 @@
         {% set type = type|default('text') %}
 
         {% if style == 'inline' and (attr.placeholder is not defined or attr.placeholder is empty)  and label != false %}
-            {% if label is empty %}
-                {% set attr = attr|merge({ 'placeholder': name|humanize }) %}
-            {% else %}
-                {% set attr = attr|merge({ 'placeholder': label}) %}
-            {% endif %}
+          {% if label_format is defined and label_format is not empty %}
+              {% set attr = attr|merge({ 'placeholder': label_format|replace({
+                  '%name%': name,
+                  '%id%': id,
+              }) }) %}
+          {% elseif label is empty %}
+              {% set attr = attr|merge({ 'placeholder': name|humanize }) %}
+          {% else %}
+              {% set attr = attr|merge({ 'placeholder': label}) %}
+          {% endif %}
         {% endif %}
 
         {% if static_control is defined and static_control == true %}
@@ -268,7 +273,12 @@
             {% if required %}
                 {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
             {% endif %}
-            {% if label is empty %}
+            {% if label_format is defined and label_format is not empty %}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {% elseif label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
@@ -337,7 +347,12 @@
             {% if required %}
                 {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
             {% endif %}
-            {% if label is empty %}
+            {% if label_format is defined and label_format is not empty %}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {% elseif label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
@@ -502,7 +517,12 @@
 
 {% block button_widget %}
     {% spaceless %}
-        {% if label is empty and label is not sameas(false) %}
+        {% if label_format is defined and label_format is not empty and label is not sameas(false) %}
+            {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+            }) %}
+        {% elseif label is empty and label is not sameas(false) %}
             {% set label = name|humanize %}
         {% endif %}
         {% if type is defined and type == 'submit' %}
@@ -580,7 +600,12 @@
             {% if required %}
                 {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
             {% endif %}
-            {% if label is empty %}
+            {% if label_format is defined and label_format is not empty %}
+              {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+              }) %}
+            {% elseif label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain)|raw }}</label>


### PR DESCRIPTION
Hey guys,

first off, thanks for this bundle! Been using it for a lot of my 'skeleton' projects and especially appreciate the ability to supply my own `variables.less`.

I made a small change to your form-template so that it now supports the new `label_format` option that was added in Symfony 2.6: https://github.com/symfony/symfony/pull/12050. I use this style of label translation a lot in my projects at home and at work, so it would be nice to have this supported in your bundle as well.

I've made sure to use `is defined` tests to keep compatibility with earlier versions. 

Let me know if this needs some fixes/tweaks, happy to modify!

Cheers!
