### PR TITLE
Exclude iterable attrvalue from displaying

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -905,7 +905,7 @@
             {% set attr = attr|merge({ 'style': null }) %}
         {% endif %}
         {% if id is not empty %}id="{{ id }}" {% endif %}
-        {% for attrname, attrvalue in attr %}{% if attrvalue is not null %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
+        {% for attrname, attrvalue in attr %}{% if attrvalue is not null and (attrvalue is not iterable) %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
     {% endspaceless %}
 {% endblock widget_container_attributes %}
 


### PR DESCRIPTION
I believe the commit is self explanatory, sometimes I need to set child attributes for choice field. For instance:
```php
$builder->add('is_member_of_fund', 'choice', array(
            'expanded' => true,
            'label'    => 'Is trustee a member of the fund?',
            'choices'  => array(
                '1' => 'Yes',
                '0' => 'No'
            ),
            'attr' => array(
                'child_attr' => array(
                'data-bind' => "checked: {$options['knockoutJsNS']}.isMemberOfFund")
            ),
        ));
```

Regards, Bernard