### PR TITLE
TwigBundle 2.6 configuration patch

### DIFF
--- a/DependencyInjection/BraincraftedBootstrapExtension.php
+++ b/DependencyInjection/BraincraftedBootstrapExtension.php
@@ -162,7 +162,7 @@ class BraincraftedBootstrapExtension extends Extension implements PrependExtensi
                 case 'twig':
                     $container->prependExtensionConfig(
                         $name,
-                        array('form'  => array('resources' => array($this->formTemplate)))
+                        array('form_themes' => array($this->formTemplate))
                     );
                     break;
             }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require":      {
         "php":                      ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
-        "symfony/twig-bundle":      "~2.3",
+        "symfony/twig-bundle":      "~2.6",
         "symfony/form":             "~2.3",
         "symfony/console":          "~2.3",
         "symfony/finder":           "~2.3"


### PR DESCRIPTION
Hi, Is it possible to make bundle compatible with Sf2.6+?
Twig bundle 2.6+ triggers error on setting ```twig.form.resources```. ```twig.form_themes``` should be used instead (but ```%twig.form.resources%``` parameter is set for BC)

Here is the patch to represent changes.