### PR TITLE
this updates the form_themes supported keyword to replace the form.resources keyword

### DIFF
--- a/DependencyInjection/BraincraftedBootstrapExtension.php
+++ b/DependencyInjection/BraincraftedBootstrapExtension.php
@@ -162,7 +162,7 @@ class BraincraftedBootstrapExtension extends Extension implements PrependExtensi
                 case 'twig':
                     $container->prependExtensionConfig(
                         $name,
-                        array('form'  => array('resources' => array($this->formTemplate)))
+                        array('form_themes'  => array($this->formTemplate))
                     );
                     break;
             }


### PR DESCRIPTION
                            
|Q            |A           |
|---          |---         |
|Bug Fix?     |n           |
|New Feature? |n           |
|BC Breaks?   |n           |
|Deprecations?|n           |
|Tests Pass?  |n           |
|Fixed Tickets|not reported|
|License      |MIT         |
|Doc PR       |none        |
                            

This fixes the deprecated warning on symfony2.7 projects. It is also fully compatible backwards since the extension in twig will define the former parameters as well just in case.