### PR TITLE
Upgraded to Symfony 2.6 compatible form types (#374)

### DIFF
--- a/Form/Type/BootstrapCollectionType.php
+++ b/Form/Type/BootstrapCollectionType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * BootstrapCollectionType
@@ -54,7 +54,7 @@ class BootstrapCollectionType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $optionsNormalizer = function (Options $options, $value) {
             // @codeCoverageIgnoreStart

--- a/Form/Type/BootstrapCollectionType.php
+++ b/Form/Type/BootstrapCollectionType.php
@@ -77,7 +77,7 @@ class BootstrapCollectionType extends AbstractType
             'options'            => array(),
         ));
 
-        $resolver->setNormalizers(array('options' => $optionsNormalizer));
+        $resolver->setNormalizer('options', $optionsNormalizer);
     }
 
     /**

--- a/Form/Type/FormActionsType.php
+++ b/Form/Type/FormActionsType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\ButtonBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class FormActionsType
@@ -80,7 +80,7 @@ class FormActionsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
                 'buttons'        => array(),

--- a/Form/Type/FormStaticControlType.php
+++ b/Form/Type/FormStaticControlType.php
@@ -6,7 +6,7 @@
 namespace Braincrafted\Bundle\BootstrapBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * FormStaticControlType
@@ -23,7 +23,7 @@ class FormStaticControlType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             //'mapped'         => false,

--- a/Tests/Form/Type/BootstrapCollectionTypeTest.php
+++ b/Tests/Form/Type/BootstrapCollectionTypeTest.php
@@ -56,7 +56,7 @@ class BootstrapCollectionTypeTest extends \PHPUnit_Framework_TestCase
     {
         $resolver = m::mock('Symfony\Component\OptionsResolver\OptionsResolver');
         $resolver->shouldReceive('setDefaults');
-        $resolver->shouldReceive('setNormalizers');
+        $resolver->shouldReceive('setNormalizer');
 
         $this->type->configureOptions($resolver);
     }

--- a/Tests/Form/Type/BootstrapCollectionTypeTest.php
+++ b/Tests/Form/Type/BootstrapCollectionTypeTest.php
@@ -50,15 +50,15 @@ class BootstrapCollectionTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Braincrafted\Bundle\BootstrapBundle\Form\Type\BootstrapCollectionType::setDefaultOptions()
+     * @covers Braincrafted\Bundle\BootstrapBundle\Form\Type\BootstrapCollectionType::configureOptions()
      */
-    public function testSetDefaultOptions()
+    public function testConfigureOptions()
     {
-        $resolver = m::mock('Symfony\Component\OptionsResolver\OptionsResolverInterface');
+        $resolver = m::mock('Symfony\Component\OptionsResolver\OptionsResolver');
         $resolver->shouldReceive('setDefaults');
         $resolver->shouldReceive('setNormalizers');
 
-        $this->type->setDefaultOptions($resolver);
+        $this->type->configureOptions($resolver);
     }
 
     /**

--- a/Tests/Form/Type/FormActionsTypeTest.php
+++ b/Tests/Form/Type/FormActionsTypeTest.php
@@ -90,7 +90,7 @@ class FormActionsTypeTest extends \PHPUnit_Framework_TestCase
         $this->type->buildView($view, $form, $options);
     }
 
-    public function testSetDefaultOptions()
+    public function testConfigureOptions()
     {
 
         $defaults = array(
@@ -99,10 +99,10 @@ class FormActionsTypeTest extends \PHPUnit_Framework_TestCase
             'mapped'         => false,
         );
 
-        $resolver = m::mock('Symfony\Component\OptionsResolver\OptionsResolverInterface');
+        $resolver = m::mock('Symfony\Component\OptionsResolver\OptionsResolver');
         $resolver->shouldReceive('setDefaults')->with($defaults)->once();
 
-        $this->type->setDefaultOptions($resolver);
+        $this->type->configureOptions($resolver);
     }
 
     public function testGetName()


### PR DESCRIPTION
This removed deprecated OptionsResolverInterface.