### PR TITLE
Render option attr of collapsed choice types

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -222,7 +222,9 @@
                     {{ block('choice_widget_options') }}
                 </optgroup>
             {% else %}
-                <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+                {% set id = null %}
+                {% set attr = (attribute(choice, 'attr') is defined) ? choice.attr : [] %}
+                <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}{{ block('widget_container_attributes') }}>{{ choice.label|trans({}, translation_domain) }}</option>
             {% endif %}
         {% endfor %}
     {% endspaceless %}


### PR DESCRIPTION
Symfony 2.7 introduced the (still undocumented) ability to set HTML attributes for the choices in a _choice_ form type. See [PR 14050](https://github.com/symfony/symfony/pull/14050)

This already works fine for _expanded_ choice fields, but not for _collapsed_ fields, which get rendered as `<select>` with `<option>`s.

This small tweak in the form view adds this functionality, and is backwards compatible.

---

```php
$choiceAttr = function ($choice, $key) {
    // this does not really make sens, it's just here to demo populating ChoiceView::$attr
    return array(
        'data-upper' => strtoupper($choice),
    );
};

$builder->add('bar', 'choice', array(
    'choices' => array(
        'a' => 'Bar A',
        'b' => 'Bar B'
    ),
    'expanded' => false,
    'choice_attr' => $choiceAttr,
));
```

Would now render as

```html
<select id="form_bar" name="form[bar]" required="required" class="form-control">
    <option value="a" data-upper="A">Bar A</option>
    <option value="b" data-upper="B">Bar B</option>
</select>
```