### PR TITLE
[WIP] Pass affected elements as extra parameter in collection js events

### DIFF
--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -50,19 +50,20 @@
         newWidget = newWidget.replace(/__id__/g, newName[1].replace(re, count));
         var newLi = $('<li></li>').html(newWidget);
         newLi.appendTo(list);
-        $this.trigger('bc-collection-field-added');
+        $this.trigger('bc-collection-field-added', [newLi, collection]);
     };
 
     CollectionRemove.prototype.removeField = function (e) {
         var $this = $(this),
+            li = $this.closest('li'),
             selector = $this.attr('data-field')
         ;
 
         e && e.preventDefault();
 
-        $this.trigger('bc-collection-field-removed');
-        var listElement = $this.closest('li').remove();
-    }
+        $this.trigger('bc-collection-field-removed', [li]);
+        var listElement = li.remove();
+    };
 
 
     /* COLLECTION PLUGIN DEFINITION
@@ -86,7 +87,7 @@
     };
 
     $.fn.removeField = function (option) {
-        return this.each(function() {
+        return this.each(function () {
             var $this = $(this),
                 data = $this.data('removefield')
             ;
@@ -109,11 +110,11 @@
     $.fn.addField.noConflict = function () {
         $.fn.addField = oldAdd;
         return this;
-    }
+    };
     $.fn.removeField.noConflict = function () {
         $.fn.removeField = oldRemove;
         return this;
-    }
+    };
 
 
     /* COLLECTION DATA-API
@@ -122,5 +123,4 @@
     $(document).on('click.addfield.data-api', addField, CollectionAdd.prototype.addField);
     $(document).on('click.removefield.data-api', removeField, CollectionRemove.prototype.removeField);
 
- }(window.jQuery);
- 
+}(window.jQuery);


### PR DESCRIPTION
_This PR is an expansion of issue #311_

This small change allows you to use the JS events triggered in `bc-bootstrap-collection.js` more effectively, as it passes the affected list elements as [_extra parameter_](http://api.jquery.com/trigger/).

These parameters are available in the event listeners attached with jQuery's [.on()](http://api.jquery.com/on/). With this in place there's no need for 'guessing' which element was added. (e.g. getting the last child of the `<ul>`, which isn't necessarily the right element)

Example usage:
```twig
{% block javascripts %}
    {{- parent() }}
    <script>
        (function ($) {

            var $commentsCollection = $('{{ '#' ~ edit_form.comments.vars.id }}');

            $commentsCollection
                    .on('bc-collection-field-added', function (e, $item, $collection) {
                        console.log('comment form added to collection: ', $item);
                        $item.find(':input:first').focus();
                    })
                    .on('bc-collection-field-removed', function (e, $item) {
                        console.log('comment form removed from collection: ', $item);
                        // do nothing :)

                        // note: it's a bit weird the event gets fired _before_ the element is removed,
                        // but if we trigger if after the remove(), this event will not be caught.
                    })
            ;

        })(jQuery);
    </script>
{% endblock %}
```

**The changes here should be backwards compatible, and this PR could be merged right away, but I would like to discuss something here:**

I see still some issues with the current script.
Firstly, the events are triggered on the add and removed _buttons_, rather that on the collection (div) for example. Imho this is a bit weird, and causes a problem if we would change the moment the removed event is triggered.
Which brings me to issue two; the `bc-collection-field-removed` event is triggered _before_ the element is removed. We could swap this around, but this won't work with listeners attached to the collection (like in the example above), as the removed `<li>` has no ancestors to bubble the event to.

My suggestion would be to use the collection element (the `<div>`) as the _attached_ element, and use the parameters (like done in this commit) to pass the relevant `<li>`. We can than trigger the deleted event after the element is removed.

As this suggestion would cause breaking changes I would love some feedback on this.