### PR TITLE
Use url option instead if href attribute

### DIFF
--- a/Tests/Twig/BootstrapButtonExtensionTest.php
+++ b/Tests/Twig/BootstrapButtonExtensionTest.php
@@ -108,19 +108,19 @@ class BootstrapButtonExtensionTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'label'     => 'Test',
             'icon'      => 'check',
+            'url'       => 'example.com',
             'type'      => 'success',
             'size'      => 'sm',
             'attr'      => array(
                 'id'            => 'test_button',
                 'class'         => 'my-class',
-                'href'          => 'example.com',
                 'title'         => 'Test',
                 'data-confirm'  => 'Are you sure?'
             ),
         );
 
         $this->assertEquals(
-            '<a id="test_button" class="btn btn-success btn-sm my-class" href="example.com" title="Test" data-confirm="Are you sure?"><i class="fa fa-check"></i> Test</a>',
+            '<a id="test_button" class="btn btn-success btn-sm my-class" title="Test" data-confirm="Are you sure?" href="example.com"><i class="fa fa-check"></i> Test</a>',
             $this->extension->buttonLinkFunction($options),
             '->buttonFunction() returns the HTML code for the given button.'
         );

--- a/Twig/BootstrapButtonExtension.php
+++ b/Twig/BootstrapButtonExtension.php
@@ -68,7 +68,7 @@ class BootstrapButtonExtension extends \Twig_Extension
         $options = array_merge($this->defaults, $options);
 
         $options['attr']['class'] = "btn btn-{$options['type']} btn-{$options['size']}" . (isset($options['attr']['class']) ? ' '.$options['attr']['class'] : '');
-        $options['attr']['href'] = (isset($options['attr']['href']) ? $options['attr']['href'] : '#');
+        $options['attr']['href'] = (isset($options['url']) ? $options['url'] : '#');
 
         $icon   = $options['icon'] ? $this->iconExtension->iconFunction($options['icon']).' ' : '';
         $attr   = $options['attr'] ? $this->attributes($options['attr']) : '';


### PR DESCRIPTION
Update to my last commit https://github.com/braincrafted/bootstrap-bundle/pull/383

This PR allows using ```button_link``` like that (shorten and more intuitive)
```twig
{{ button_link({
            'label': 'Test',
            'url': 'example.com',
}) }}
```

instead of
```twig
{{ button_link({
            'label': 'Test',
            'attr': {
                'href': 'example.com',
            },
}) }}
```

@florianeckerstorfer Please merge this small update