### PR TITLE
knp_menu_base.html.twig does not exists

### DIFF
--- a/Resources/views/Menu/bootstrap.html.twig
+++ b/Resources/views/Menu/bootstrap.html.twig
@@ -1,5 +1,3 @@
-{% extends 'knp_menu_base.html.twig' %}
-
 {% macro attributes(attributes) %}
 {% for name, value in attributes %}
     {%- if value is not none and value is not sameas(false) -%}


### PR DESCRIPTION
The file ```knp_menu_base.html.twig``` does not exists in ```@BraincraftedBootstrap/Menu/bootstrap.html.twig```
```
  - braincrafted/bootstrap-bundle (v2.1.2)
  - knplabs/knp-menu-bundle (v1.1.2)
```
ref https://github.com/braincrafted/bootstrap-bundle/issues/387