### PR TITLE
Use icon helper with different icon-set

### DIFF
--- a/Tests/Twig/BootstrapIconExtensionTest.php
+++ b/Tests/Twig/BootstrapIconExtensionTest.php
@@ -62,6 +62,23 @@ class BootstrapIconExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Braincrafted\Bundle\BootstrapBundle\Twig\BootstrapIconExtension::iconFunction
+     */
+    public function testIconFilterWithDifferntPrefix()
+    {
+        $this->assertEquals(
+            '<span class="glyphicon glyphicon-heart"></span>',
+            $this->getIconExtension('default')->iconFunction('heart', 'glyphicon'),
+            '->iconFunction() returns the HTML code for the given icon.'
+        );
+        $this->assertEquals(
+            '<span class="fa fa-heart"></span>',
+            $this->getIconExtension('default')->iconFunction('heart', 'fa'),
+            '->iconFunction() uses the iconPrefix passed into the IconExtension constructor.'
+        );
+    }
+
+    /**
      * @covers Braincrafted\Bundle\BootstrapBundle\Twig\BootstrapIconExtension::parseIconsFilter
      */
     public function testParseIconsFilter()
@@ -75,6 +92,24 @@ class BootstrapIconExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             '<span class="fa fa-heart"></span> foobar',
             $this->getIconExtension('fa')->parseIconsFilter('.icon-heart foobar'),
+            '->parseIconsFilter() uses the iconPrefix passed into the IconExtension constructor.'
+        );
+    }
+
+    /**
+     * @covers Braincrafted\Bundle\BootstrapBundle\Twig\BootstrapIconExtension::parseIconsFilter
+     */
+    public function testParseIconsFilterWithDifferntPrefix()
+    {
+        $this->assertEquals(
+            '<span class="glyphicon glyphicon-heart"></span> foobar',
+            $this->getIconExtension('default')->parseIconsFilter('.glyphicon-heart foobar'),
+            '->parseIconsFilter() returns the HTML code with the replaced icons.'
+        );
+
+        $this->assertEquals(
+            '<span class="fa fa-heart"></span> foobar',
+            $this->getIconExtension('default')->parseIconsFilter('.fa-heart foobar'),
             '->parseIconsFilter() uses the iconPrefix passed into the IconExtension constructor.'
         );
     }

--- a/Twig/BootstrapIconExtension.php
+++ b/Twig/BootstrapIconExtension.php
@@ -82,9 +82,9 @@ class BootstrapIconExtension extends Twig_Extension
         $that = $this;
 
         return preg_replace_callback(
-            '/\.icon-([a-z0-9+-]+)/',
+            '/\.([a-z]+)-([a-z0-9+-]+)/',
             function ($matches) use ($that) {
-                return $that->iconFunction($matches[1]);
+                return $that->iconFunction($matches[2], $matches[1]);
             },
             $text
         );
@@ -94,14 +94,16 @@ class BootstrapIconExtension extends Twig_Extension
      * Returns the HTML code for the given icon.
      *
      * @param string $icon The name of the icon
+     * @param string $iconSet The icon-set name
      *
      * @return string The HTML code for the icon
      */
-    public function iconFunction($icon)
+    public function iconFunction($icon, $iconSet = 'icon')
     {
-        $icon = str_replace('+', ' '.$this->iconPrefix.'-', $icon);
+        if ($iconSet == 'icon') $iconSet = $this->iconPrefix;
+        $icon = str_replace('+', ' '.$iconSet.'-', $icon);
 
-        return sprintf('<%1$s class="%2$s %2$s-%3$s"></%1$s>', $this->iconTag, $this->iconPrefix, $icon);
+        return sprintf('<%1$s class="%2$s %2$s-%3$s"></%1$s>', $this->iconTag, $iconSet, $icon);
     }
 
     /**


### PR DESCRIPTION
In my project I'm using three different icon sets **fa-*** *(fontawesome)*, **glyphicons-*** *(glyphicons)*, **md-*** *(material-design)* for different sections: frontend and backend.

By this commit I can use the ```icon``` function like this:
```twig
{{ icon('camera') }}
{{ icon('alert', 'md') }}
{{ icon('user+fw', 'fa') }}
```
and the ```parse_icons``` filter like this:
```twig
{{ '.icon-heart'|parse_icons }}
{{ '.md-alert'|parse_icons }}
{{ '.fa-user+fw'|parse_icons }}
```
and will render to:
```html
<i class="glyphicon glyphicon-heart"></i>
<i class="md md-alert"></i>
<i class="fa fa-user fa-fw"></i>
```