### PR TITLE
Switched twig extensions to use SimpleFunction/SimpleFilter

### DIFF
--- a/Twig/BootstrapBadgeExtension.php
+++ b/Twig/BootstrapBadgeExtension.php
@@ -8,7 +8,7 @@
 namespace Braincrafted\Bundle\BootstrapBundle\Twig;
 
 use Twig_Extension;
-use Twig_Function_Method;
+use Twig_SimpleFunction;
 
 /**
  * BootstrapLabelExtension
@@ -29,9 +29,9 @@ class BootstrapBadgeExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            'badge' => new Twig_Function_Method(
-                $this,
-                'badgeFunction',
+            new Twig_SimpleFunction(
+                'badge',
+                array($this, 'badgeFunction'),
                 array('pre_escape' => 'html', 'is_safe' => array('html'))
             )
         );

--- a/Twig/BootstrapButtonExtension.php
+++ b/Twig/BootstrapButtonExtension.php
@@ -6,7 +6,10 @@
 
 namespace Braincrafted\Bundle\BootstrapBundle\Twig;
 
-class BootstrapButtonExtension extends \Twig_Extension
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+class BootstrapButtonExtension extends Twig_Extension
 {
     /**
      * @var BootstrapIconExtension
@@ -35,8 +38,8 @@ class BootstrapButtonExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('button', array($this, 'buttonFunction'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('button_link', array($this, 'buttonLinkFunction'), array('is_safe' => array('html'))),
+            new Twig_SimpleFunction('button', array($this, 'buttonFunction'), array('is_safe' => array('html'))),
+            new Twig_SimpleFunction('button_link', array($this, 'buttonLinkFunction'), array('is_safe' => array('html'))),
         );
     }
 

--- a/Twig/BootstrapFormExtension.php
+++ b/Twig/BootstrapFormExtension.php
@@ -6,6 +6,10 @@
 
 namespace Braincrafted\Bundle\BootstrapBundle\Twig;
 
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+
 /**
  * BootstrapFormExtension
  *
@@ -16,7 +20,7 @@ namespace Braincrafted\Bundle\BootstrapBundle\Twig;
  * @license    http://opensource.org/licenses/MIT The MIT License
  * @link       http://bootstrap.braincrafted.com Bootstrap for Symfony2
  */
-class BootstrapFormExtension extends \Twig_Extension
+class BootstrapFormExtension extends Twig_Extension
 {
     /** @var string */
     private $style;
@@ -42,33 +46,36 @@ class BootstrapFormExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('bootstrap_set_style', array($this, 'setStyle')),
-            new \Twig_SimpleFunction('bootstrap_get_style', array($this, 'getStyle')),
-            new \Twig_SimpleFunction('bootstrap_set_col_size', array($this, 'setColSize')),
-            new \Twig_SimpleFunction('bootstrap_get_col_size', array($this, 'getColSize')),
-            new \Twig_SimpleFunction('bootstrap_set_widget_col', array($this, 'setWidgetCol')),
-            new \Twig_SimpleFunction('bootstrap_get_widget_col', array($this, 'getWidgetCol')),
-            new \Twig_SimpleFunction('bootstrap_set_label_col', array($this, 'setLabelCol')),
-            new \Twig_SimpleFunction('bootstrap_get_label_col', array($this, 'getLabelCol')),
-            new \Twig_SimpleFunction('bootstrap_set_simple_col', array($this, 'setSimpleCol')),
-            new \Twig_SimpleFunction('bootstrap_get_simple_col', array($this, 'getSimpleCol')),
-            new \Twig_SimpleFunction('bootstrap_backup_form_settings', array($this, 'backupFormSettings')),
-            new \Twig_SimpleFunction('bootstrap_restore_form_settings', array($this, 'restoreFormSettings')),
-            'checkbox_row'  => new \Twig_Function_Node(
-                'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
-                array('is_safe' => array('html'))
+            new Twig_SimpleFunction('bootstrap_set_style', array($this, 'setStyle')),
+            new Twig_SimpleFunction('bootstrap_get_style', array($this, 'getStyle')),
+            new Twig_SimpleFunction('bootstrap_set_col_size', array($this, 'setColSize')),
+            new Twig_SimpleFunction('bootstrap_get_col_size', array($this, 'getColSize')),
+            new Twig_SimpleFunction('bootstrap_set_widget_col', array($this, 'setWidgetCol')),
+            new Twig_SimpleFunction('bootstrap_get_widget_col', array($this, 'getWidgetCol')),
+            new Twig_SimpleFunction('bootstrap_set_label_col', array($this, 'setLabelCol')),
+            new Twig_SimpleFunction('bootstrap_get_label_col', array($this, 'getLabelCol')),
+            new Twig_SimpleFunction('bootstrap_set_simple_col', array($this, 'setSimpleCol')),
+            new Twig_SimpleFunction('bootstrap_get_simple_col', array($this, 'getSimpleCol')),
+            new Twig_SimpleFunction('bootstrap_backup_form_settings', array($this, 'backupFormSettings')),
+            new Twig_SimpleFunction('bootstrap_restore_form_settings', array($this, 'restoreFormSettings')),
+            new Twig_SimpleFunction(
+                'checkbox_row',
+                null,
+                array('is_safe' => array('html'), 'node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode')
             ),
-            'radio_row'  => new \Twig_Function_Node(
-                'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
-                array('is_safe' => array('html'))
+            new Twig_SimpleFunction(
+                'radio_row',
+                null,
+                array('is_safe' => array('html'), 'node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode')
             ),
-            'global_form_errors'  => new \Twig_Function_Node(
-                'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode',
-                array('is_safe' => array('html'))
+            new Twig_SimpleFunction(
+                'global_form_errors',
+                null,
+                array('is_safe' => array('html'), 'node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode')
             ),
-            'form_control_static'   => new \Twig_Function_Method(
-                $this,
-                'formControlStaticFunction',
+            new Twig_SimpleFunction(
+                'form_control_static',
+                array($this, 'formControlStaticFunction'),
                 array('is_safe' => array('html'))
             )
         );

--- a/Twig/BootstrapIconExtension.php
+++ b/Twig/BootstrapIconExtension.php
@@ -7,8 +7,8 @@
 namespace Braincrafted\Bundle\BootstrapBundle\Twig;
 
 use Twig_Extension;
-use Twig_Filter_Method;
-use Twig_Function_Method;
+use Twig_SimpleFilter;
+use Twig_SimpleFunction;
 
 /**
  * BootstrapIconExtension
@@ -48,9 +48,9 @@ class BootstrapIconExtension extends Twig_Extension
     public function getFilters()
     {
         return array(
-            'parse_icons' => new Twig_Filter_Method(
-                $this,
-                'parseIconsFilter',
+            new Twig_SimpleFilter(
+                'parse_icons',
+                array($this, 'parseIconsFilter'),
                 array('pre_escape' => 'html', 'is_safe' => array('html'))
             )
         );
@@ -62,9 +62,9 @@ class BootstrapIconExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            'icon' => new Twig_Function_Method(
-                $this,
-                'iconFunction',
+            new Twig_SimpleFunction(
+                'icon',
+                array($this, 'iconFunction'),
                 array('pre_escape' => 'html', 'is_safe' => array('html'))
             )
         );

--- a/Twig/BootstrapLabelExtension.php
+++ b/Twig/BootstrapLabelExtension.php
@@ -8,7 +8,7 @@
 namespace Braincrafted\Bundle\BootstrapBundle\Twig;
 
 use Twig_Extension;
-use Twig_Function_Method;
+use Twig_SimpleFunction;
 
 /**
  * BootstrapLabelExtension
@@ -31,12 +31,12 @@ class BootstrapLabelExtension extends Twig_Extension
         $options = array('pre_escape' => 'html', 'is_safe' => array('html'));
 
         return array(
-            'label'          => new Twig_Function_Method($this, 'labelFunction', $options),
-            'label_primary'  => new Twig_Function_Method($this, 'labelPrimaryFunction', $options),
-            'label_success'  => new Twig_Function_Method($this, 'labelSuccessFunction', $options),
-            'label_info'     => new Twig_Function_Method($this, 'labelInfoFunction', $options),
-            'label_warning'  => new Twig_Function_Method($this, 'labelWarningFunction', $options),
-            'label_danger'   => new Twig_Function_Method($this, 'labelDangerFunction', $options)
+            new Twig_SimpleFunction('label', array($this, 'labelFunction'), $options),
+            new Twig_SimpleFunction('label_primary', array($this, 'labelPrimaryFunction'), $options),
+            new Twig_SimpleFunction('label_success', array($this, 'labelSuccessFunction'), $options),
+            new Twig_SimpleFunction('label_info', array($this, 'labelInfoFunction'), $options),
+            new Twig_SimpleFunction('label_warning', array($this, 'labelWarningFunction'), $options),
+            new Twig_SimpleFunction('label_danger', array($this, 'labelDangerFunction'), $options)
         );
     }
 


### PR DESCRIPTION
Previous methods have been deprecated as of Twig ~~1.28~~ 1.21 and Symfony 2.7+ triggers
deprecation errors

Addresses more deprecations triggered by Symfony 2.7 (similar to issues identified in #377 & #378)