### PR TITLE
change js removeField event to allow catch after removing element

### DIFF
--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -55,13 +55,15 @@
 
     CollectionRemove.prototype.removeField = function (e) {
         var $this = $(this),
-            selector = $this.attr('data-field')
+            selector = $this.attr('data-field'),
+            parent = $this.closest('li').parent()
         ;
 
         e && e.preventDefault();
 
-        $this.trigger('bc-collection-field-removed');
+        // $this.trigger('bc-collection-field-removed');
         var listElement = $this.closest('li').remove();
+        parent.trigger('bc-collection-field-removed');
     }
 
 

--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -61,9 +61,10 @@
 
         e && e.preventDefault();
 
-        // $this.trigger('bc-collection-field-removed');
+        $this.trigger('bc-collection-field-removed');
+        $this.trigger('bc-collection-field-removed-before');
         var listElement = $this.closest('li').remove();
-        parent.trigger('bc-collection-field-removed');
+        parent.trigger('bc-collection-field-removed-after');
     }
 
 


### PR DESCRIPTION
This mod allow to catch event after deleting element with this sample code
```js
$('#container').on('bc-collection-field-removed-after', function (e) {
     // do sth after delete
});