### PR TITLE
Fixed bc-bootstrap-collection.js .size() deprecations.

### DIFF
--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -34,7 +34,7 @@
 
         var collection = $('#'+selector),
             list = collection.find('> ul'),
-            count = list.find('> li').size()
+            count = list.find('> li').length
         ;
 
         var newWidget = collection.attr('data-prototype');
@@ -43,7 +43,7 @@
         // If it does, increase the count by one and try again
         var newName = newWidget.match(/id="(.*?)"/);
         var re = new RegExp(prototypeName, "g");
-        while ($('#' + newName[1].replace(re, count)).size() > 0) {
+        while ($('#' + newName[1].replace(re, count)).length > 0) {
             count++;
         }
         newWidget = newWidget.replace(re, count);


### PR DESCRIPTION
The .size() method is deprecated as of jQuery 1.8. Use the .length property instead.

The .size() method is functionally equivalent to the .length property; however, the .length property is preferred because it does not have the overhead of a function call.

https://api.jquery.com/size/