### PR TITLE
Fix translator issues (warnings about missing translations)

### DIFF
--- a/Resources/views/Form/bootstrap.html.twig
+++ b/Resources/views/Form/bootstrap.html.twig
@@ -80,6 +80,12 @@
 
 {% block bootstrap_collection_widget %}
     {% spaceless %}
+        {% set delete_button_text = form.vars.delete_button_text %}
+        {% set add_button_text = form.vars.add_button_text %}
+        {% if translation_domain is not same as (false) %}
+            {% set delete_button_text = delete_button_text|trans({}, translation_domain) %}
+            {% set add_button_text = add_button_text|trans({}, translation_domain) %}
+        {% endif %}
         {% if prototype is defined %}
             {% set prototype_vars = {} %}
             {% if style is defined %}
@@ -87,7 +93,7 @@
             {% endif %}
             {% set prototype_html = '<div class="col-xs-' ~ form.vars.sub_widget_col ~ '">' ~ form_widget(prototype, prototype_vars) ~ '</div>' %}
             {% if form.vars.allow_delete %}
-                {% set prototype_html = prototype_html ~ '<div class="col-xs-' ~ form.vars.button_col ~ '"><a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="__id__">' ~ form.vars.delete_button_text|trans({}, translation_domain)|parse_icons|raw ~ '</a></div>' %}
+                {% set prototype_html = prototype_html ~ '<div class="col-xs-' ~ form.vars.button_col ~ '"><a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="__id__">' ~ delete_button_text|parse_icons|raw ~ '</a></div>' %}
             {% endif %}
             {% set prototype_html = '<div class="row">' ~ prototype_html ~ '</div>' %}
 
@@ -105,7 +111,7 @@
                             </div>
                             {% if form.vars.allow_delete %}
                                 <div class="col-xs-{{ form.vars.button_col }}">
-                                    <a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="{{ field.vars.id }}">{{ form.vars.delete_button_text|trans({}, translation_domain)|parse_icons|raw }}</a>
+                                    <a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="{{ field.vars.id }}">{{ delete_button_text|parse_icons|raw }}</a>
                                 </div>
                             {% endif %}
                         </div>
@@ -113,7 +119,7 @@
                 {% endfor %}
             </ul>
             {% if form.vars.allow_add %}
-                <a href="#" class="btn btn-primary btn-sm" data-addfield="collection" data-collection="{{ form.vars.id }}" data-prototype-name="{{ prototype_name }}">{{ form.vars.add_button_text|trans({}, translation_domain)|parse_icons|raw }}</a>
+                <a href="#" class="btn btn-primary btn-sm" data-addfield="collection" data-collection="{{ form.vars.id }}" data-prototype-name="{{ prototype_name }}">{{ add_button_text|parse_icons|raw }}</a>
             {% endif %}
         </div>
     {% endspaceless %}
@@ -258,27 +264,27 @@
         {% endif %}
 
         {%set checkboxdata %}
-        {% if label is not same as (false) %}
-            {% if not compound %}
-                {% set label_attr = label_attr|merge({'for': id}) %}
+            {% if label is not same as (false) %}
+                {% if not compound %}
+                    {% set label_attr = label_attr|merge({'for': id}) %}
+                {% endif %}
+                {% if inline is defined and inline %}
+                    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' checkbox-inline')|trim}) %}
+                {% endif %}
+                {% if required %}
+                    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+                {% endif %}
+                {% if label is empty %}
+                    {% set label = name|humanize %}
+                {% endif %}
+                <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{ block('checkbox_widget') }}
+                {{ translation_domain is same as (false) ? label|raw : label|trans({}, translation_domain)|raw -}}
+                </label>
+            {% else %}
+                {{ block('checkbox_widget') }}
             {% endif %}
-            {% if inline is defined and inline %}
-                {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' checkbox-inline')|trim}) %}
-            {% endif %}
-            {% if required %}
-                {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
-            {% endif %}
-            {% if label is empty %}
-                {% set label = name|humanize %}
-            {% endif %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{ block('checkbox_widget') }}
-            {{ label|trans({}, translation_domain)|raw -}}
-            </label>
-        {% else %}
-            {{ block('checkbox_widget') }}
-        {% endif %}
-        {{ form_errors(form) }}
+            {{ form_errors(form) }}
         {% endset %}
 
         {% if inline is defined and inline %}
@@ -327,27 +333,27 @@
         {% endif %}
 
         {%set radiodata %}
-        {% if label is not same as (false) %}
-            {% if not compound %}
-                {% set label_attr = label_attr|merge({'for': id}) %}
+            {% if label is not same as (false) %}
+                {% if not compound %}
+                    {% set label_attr = label_attr|merge({'for': id}) %}
+                {% endif %}
+                {% if inline is defined and inline %}
+                    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' radio-inline')|trim}) %}
+                {% endif %}
+                {% if required %}
+                    {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+                {% endif %}
+                {% if label is empty %}
+                    {% set label = name|humanize %}
+                {% endif %}
+                <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{ block('radio_widget') }}
+                {{ translation_domain is same as (false) ? label|raw : label|trans({}, translation_domain)|raw -}}
+                </label>
+            {% else %}
+                {{ block('radio_widget') }}
             {% endif %}
-            {% if inline is defined and inline %}
-                {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' radio-inline')|trim}) %}
-            {% endif %}
-            {% if required %}
-                {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
-            {% endif %}
-            {% if label is empty %}
-                {% set label = name|humanize %}
-            {% endif %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{ block('radio_widget') }}
-            {{ label|trans({}, translation_domain)|raw -}}
-            </label>
-        {% else %}
-            {{ block('radio_widget') }}
-        {% endif %}
-        {{ form_errors(form) }}
+            {{ form_errors(form) }}
         {% endset %}
 
         {% if inline is defined and inline %}
@@ -403,9 +409,9 @@
             {% set attr = attr|merge({ 'class': 'bootstrap-date' }) %}
             <div {{ block('widget_container_attributes') }}>
                 {{ date_pattern|replace({
-                '{{ year }}':  form_widget(form.year),
-                '{{ month }}': form_widget(form.month),
-                '{{ day }}':   form_widget(form.day),
+                    '{{ year }}':  form_widget(form.year),
+                    '{{ month }}': form_widget(form.month),
+                    '{{ day }}':   form_widget(form.day),
                 })|raw }}
             </div>
         {% endif %}
@@ -447,9 +453,9 @@
     {% spaceless %}
         <div class="input-group">
             {{ money_pattern|replace({
-            '{{ widget }}': block('form_widget_simple'),
-            '{{ tag_start }}': '<span class="input-group-addon">',
-            '{{ tag_end }}': '</span>'
+                '{{ widget }}': block('form_widget_simple'),
+                '{{ tag_start }}': '<span class="input-group-addon">',
+                '{{ tag_end }}': '</span>'
             })|raw }}
         </div>
     {% endspaceless %}
@@ -510,10 +516,13 @@
         {% else %}
             {% set attr = attr|merge({ 'class': (attr.class|default('') ~ ' btn btn-'~button_class|default('default'))|trim }) %}
         {% endif %}
+        {% if translation_domain is not same as (false) %}
+            {% set label = label|trans({}, translation_domain) %}
+        {% endif %}
         {% if as_link is defined and as_link == true %}
-            <a {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</a>
+            <a {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif -%}{{ label }}</a>
         {% else %}
-            <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label|trans({}, translation_domain) }}</button>
+            <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{% if attr.icon is defined and attr.icon != '' %}{{ icon(attr.icon) }}{% endif %}{{ label }}</button>
         {% endif %}
     {% endspaceless %}
 {% endblock button_widget %}
@@ -583,7 +592,10 @@
             {% if label is empty %}
                 {% set label = name|humanize %}
             {% endif %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain)|raw }}</label>
+            {% if translation_domain is not same as (false) %}
+                {% set label = label|trans({}, translation_domain) %}
+            {% endif %}
+            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|raw }}</label>
         {% endif %}
     {% endspaceless %}
 {% endblock form_label %}
@@ -716,13 +728,13 @@
 
         <div class="form-group">
             {% if style == 'horizontal' %}
-                <div class="col-{{ col_size }}-offset-{{ label_col }} col-{{ col_size }}-{{ widget_col }}">
-            {% endif %}
+            <div class="col-{{ col_size }}-offset-{{ label_col }} col-{{ col_size }}-{{ widget_col }}">
+                {% endif %}
 
-            {{ form_widget(form) }}
+                {{ form_widget(form) }}
 
-            {% if style == 'horizontal' %}
-                </div>
+                {% if style == 'horizontal' %}
+            </div>
             {% endif %}
         </div>
     {% endspaceless %}
@@ -813,7 +825,7 @@
         {% if bootstrap_get_simple_col() %}
             {{ bootstrap_set_simple_col(false) }}
         {% endif %}
-    {{ bootstrap_restore_form_settings() }}
+        {{ bootstrap_restore_form_settings() }}
     {% endspaceless %}
 {% endblock form_end %}
 
@@ -910,6 +922,6 @@
 {% endblock widget_container_attributes %}
 
 {% block button_attributes -%}
-        id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif %}
-        {%- for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
+    id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif %}
+    {%- for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
 {% endblock button_attributes %}

--- a/Resources/views/Menu/bootstrap.html.twig
+++ b/Resources/views/Menu/bootstrap.html.twig
@@ -188,4 +188,15 @@
 
 {% block spanElement %}<span{{ attributes(item.labelAttributes) }}>{{ block('label') }}</span>{% endblock %}
 
-{% block label %}{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'messages'))|raw|parse_icons }}{% else %}{{ item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'messages'))|parse_icons }}{% endif %}{% endblock %}
+{% block label %}
+    {%- set translation_domain = item.extra('translation_domain', 'messages') -%}
+    {%- set label = item.label -%}
+    {%- if translation_domain is not same as(false) -%}
+        {%- set label = label|trans(item.extra('translation_params', {}), translation_domain) -%}
+    {%- endif -%}
+    {%- if options.allow_safe_labels and item.getExtra('safe_label', false) -%}
+        {{ label|raw|parse_icons }}
+    {%- else -%}
+        {{ label|parse_icons }}
+    {%- endif -%}
+{% endblock %}

--- a/Resources/views/flash.html.twig
+++ b/Resources/views/flash.html.twig
@@ -8,27 +8,31 @@
 {% for flashMessage in app.session.flashbag.get('alert') %}
     <div class="alert alert-warning{% if close %} alert-dismissible{% endif %}">
         {% if close %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-        {{ flashMessage|trans({}, translation_domain) }}
+        {% if translation_domain is not same as(false) %}{% set flashMessage = flashMessage|trans({}, translation_domain) %}{% endif %}
+        {{ flashMessage }}
     </div>
 {% endfor %}
 
 {% for flashMessage in app.session.flashbag.get('danger') %}
     <div class="alert alert-danger{% if close %} alert-dismissible{% endif %}">
         {% if close %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-        {{ flashMessage|trans({}, translation_domain) }}
+        {% if translation_domain is not same as(false) %}{% set flashMessage = flashMessage|trans({}, translation_domain) %}{% endif %}
+        {{ flashMessage }}
     </div>
 {% endfor %}
 
 {% for flashMessage in app.session.flashbag.get('info') %}
     <div class="alert alert-info{% if close %} alert-dismissible{% endif %}">
         {% if close %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-        {{ flashMessage|trans({}, translation_domain) }}
+        {% if translation_domain is not same as(false) %}{% set flashMessage = flashMessage|trans({}, translation_domain) %}{% endif %}
+        {{ flashMessage }}
     </div>
 {% endfor %}
 
 {% for flashMessage in app.session.flashbag.get('success') %}
     <div class="alert alert-success{% if close %} alert-dismissible{% endif %}">
         {% if close %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-        {{ flashMessage|trans({}, translation_domain) }}
+        {% if translation_domain is not same as(false) %}{% set flashMessage = flashMessage|trans({}, translation_domain) %}{% endif %}
+        {{ flashMessage }}
     </div>
 {% endfor %}

--- a/Session/FlashMessage.php
+++ b/Session/FlashMessage.php
@@ -7,7 +7,7 @@
 
 namespace Braincrafted\Bundle\BootstrapBundle\Session;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * FlashMessage
@@ -21,15 +21,15 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class FlashMessage
 {
-    /** @var SessionInterface */
+    /** @var Session */
     private $session;
 
     /**
      * Constructor.
      *
-     * @param SessionInterface $session The session
+     * @param Session $session The session
      */
-    public function __construct(SessionInterface $session)
+    public function __construct(Session $session)
     {
         $this->session = $session;
     }

--- a/Tests/Session/FlashMessageTest.php
+++ b/Tests/Session/FlashMessageTest.php
@@ -13,7 +13,7 @@ use Braincrafted\Bundle\BootstrapBundle\Session\FlashMessage;
  */
 class FlashMessageTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface|\Mockery\MockInterface */
+    /** @var \Symfony\Component\HttpFoundation\Session\Session|\Mockery\MockInterface */
     private $session;
 
     /** @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface|\Mockery\MockInterface */
@@ -25,7 +25,7 @@ class FlashMessageTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->flashBag = m::mock('Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface');
-        $this->session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $this->session = m::mock('Symfony\Component\HttpFoundation\Session\Session');
         $this->session
             ->shouldReceive('getFlashBag')
             ->withNoArgs()


### PR DESCRIPTION
Sometimes you don't need translation, maybe you just pulled the menu-items dynamically out of the database. The Debug-Toolbar shows missing-translation errors for that entries.
Also for developing single-language apps this helps to keep the warnings away.
The easy way of just globally disabling the translation component won't work, as most of the time external bundles (as FOSUserBundle for example) rely on that translation service.

This PR provides the ability to disable the translation for each item individually for Menus, Forms and page-wise for Flash Messages.

Disabling Translation for Menu Items repects the documented way: http://symfony.com/doc/current/bundles/KnpMenuBundle/i18n.html

Disabling Translation for Forms is just adding `'translation_domain' => false` to the form fields option

``` php
$builder->add('enabled', CheckboxType::class, array(
    'label' => 'The Label', 
    'required' => false, 
    'attr' => array('align_with_widget' => true),
    'translation_domain' => false
));
```

Disabling Translation for Flash Messages is just adding a parameter to the include: 
`{% include 'BraincraftedBootstrapBundle::flash.html.twig' with { 'close': true, 'translation_domain': false } %}`
