### PR TITLE
Updating DI for JQuery.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
     const DEFAULT_BOOTSTRAP_TEMPLATE_SASS = 'BraincraftedBootstrapBundle:Bootstrap:bootstrap.scss.twig';
 
     /** @var string */
-    const DEFAULT_JQUERY_PATH = '%kernel.root_dir%/../vendor/jquery/jquery/jquery-1.11.1.js';
+    const DEFAULT_JQUERY_PATH = '%kernel.root_dir%/../vendor/frameworks/jquery/jquery.js';
 
     /** @var string */
     const DEFAULT_FONTS_DIR = '%kernel.root_dir%/../web/fonts';


### PR DESCRIPTION
JQuery Package is no longer under jquery/jquery but under frameworks/jquery 

** This should also be altered to the documentation

Note: 
Again in the documentation assetic is no longer part of the Symfony Framework (2.8+) by default. so assetic:dump will not work. You will either need to install assetic or use assets:install