### PR TITLE
Making the add field more selective.

### DIFF
--- a/Resources/js/bc-bootstrap-collection.js
+++ b/Resources/js/bc-bootstrap-collection.js
@@ -32,7 +32,7 @@
 
         e && e.preventDefault();
 
-        var collection = $('#'+selector),
+        var collection = $this.closest('form').find('#'+selector),
             list = collection.find('> ul'),
             count = list.find('> li').length
         ;


### PR DESCRIPTION
Currently the add field will add to the first item with the given selector. Well you could have a few forms with he same ids on the same page. This makes the add field more selective by finding the selector inside the closest form. Which should be the form the button is clicked from. 