### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,5 @@
     },
     "autoload": {
         "psr-4": { "Braincrafted\\Bundle\\BootstrapBundle\\": "" }
-    },
-    "target-dir": "Braincrafted/Bundle/BootstrapBundle"
+    }
 }


### PR DESCRIPTION
Hey,

I know this bundle is quite dead, but for transition reasons an update'd be cool. The problem is that Composer complains about mixing PSR-4 and `target-dir`:

>  PSR-4 autoloading is incompatible with the target-dir property, remove the target-dir in package 'braincrafted/bootstrap-bundle'.

This PR simply drops the `target-dir` value from the json.

Cheers
Matthias